### PR TITLE
add RecipesBase explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -12,3 +12,4 @@ Clustering
 FixedSizeArrays
 FastaIO
 PlotRecipes
+RecipesBase


### PR DESCRIPTION
instead of assuming it will be present as a transitive dependency