### PR TITLE
Add progress bar to SplitStockholm

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -15,3 +15,4 @@ PkgBenchmark
 NamedArrays
 JLD
 RecipesBase
+ProgressMeter

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -44,10 +44,12 @@ function main(input)
 	lines = []
 	id = "no_accessionumber"
 
-    maximum.(eachline(infh))
-    fileSize = position(infh)
-    seek(infh, 0)
-    prog = Progress(fileSize, 1)
+    if Args["progress"]:
+        maximum.(eachline(infh))
+        fileSize = position(infh)
+        seek(infh, 0)
+        prog = Progress(fileSize, 1)
+    end
 
 	for line in eachline(infh)
         line = readline(infh)
@@ -65,7 +67,9 @@ function main(input)
 			id = "no_accessionumber"
 			empty!(lines)
 		end
-        next!(prog)
+        if Args["progress"]:
+            next!(prog)
+        end
 	end
 	close(infh)
 end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -45,10 +45,11 @@ function main(input)
 
     if Args["progress"]
         totalsize = filesize(input)
-        val = totalsize
-        prog = ProgressThresh(1, "Bytes remaining:")
+        val = 0
+        prog = Progress(totalsize, 1)
     end
 
+    # for line in eachline(infh)
     while !eof(infh)
         line = readline(infh)
         if length(line) > 7 && line[1:7] == "#=GF AC"
@@ -65,7 +66,7 @@ function main(input)
             id = "no_accessionumber"
             empty!(lines)
             if Args["progress"]
-                val -= filesize(filename)
+                val += filesize(filename)
                 ProgressMeter.update!(prog, val)
             end
         end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -18,10 +18,9 @@ function parse_commandline()
                 help = "Path for the output files [default: execution directory]"
             arg_type = String
                 default = ""
-        "--progress"
-                help = "Display progress bar [default: true]"
-                arg_type = Boolean,
-                default = true
+        "--hide-progress"
+                help = "Hide the progress [default: true]"
+                action = :store_false
     end
 
     s.epilog = """
@@ -44,8 +43,8 @@ function main(input)
     lines = []
     id = "no_accessionumber"
 
-    if Args["progress"]:
-        thresh = filesize(infh)
+    if Args["progress"]
+        thresh = filesize(input)
         prog = ProgressThresh(thresh, "Bytes read:")
     end
 
@@ -64,8 +63,8 @@ function main(input)
             close(outfh)
             id = "no_accessionumber"
             empty!(lines)
-            if Args["progress"]:
-                update!(prog, prog.value + filesize(outfh))
+            if Args["progress"]
+                update!(prog, prog.val + filesize(filename))
             end
         end
     end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -18,10 +18,9 @@ function parse_commandline()
                 help = "Path for the output files [default: execution directory]"
                 arg_type = String
                 default = ""
-        "--hide-progress"
-                help = "Hide the progress [default: true]"
-                action = :store_false
-                default = :store_true
+        "--progress"
+                help = "Display the progress"
+                action = :store_true
     end
 
     s.epilog = """
@@ -44,7 +43,7 @@ function main(input)
     lines = []
     id = "no_accessionumber"
 
-    if !Args["hide-progress"]
+    if Args["progress"]
         thresh = filesize(input)
         prog = ProgressThresh(thresh, "Bytes read:")
     end
@@ -63,7 +62,7 @@ function main(input)
             close(outfh)
             id = "no_accessionumber"
             empty!(lines)
-            if !Args["hide-progress"]
+            if Args["progress"]
                 update!(prog, prog.val + filesize(filename))
             end
         end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -16,7 +16,7 @@ function parse_commandline()
             required = true
         "--path", "-p"
                 help = "Path for the output files [default: execution directory]"
-            arg_type = String
+                arg_type = String
                 default = ""
         "--hide-progress"
                 help = "Hide the progress [default: true]"
@@ -43,13 +43,12 @@ function main(input)
     lines = []
     id = "no_accessionumber"
 
-    if Args["progress"]
+    if !Args["hide-progress"]
         thresh = filesize(input)
         prog = ProgressThresh(thresh, "Bytes read:")
     end
 
-    while !eof(infh)
-        line = readline(infh)
+    for line in eachline(infh)
         if length(line) > 7 && line[1:7] == "#=GF AC"
             id = get_n_words(line, 3)[3]
         end
@@ -63,7 +62,7 @@ function main(input)
             close(outfh)
             id = "no_accessionumber"
             empty!(lines)
-            if Args["progress"]
+            if !Args["hide-progress"]
                 update!(prog, prog.val + filesize(filename))
             end
         end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -15,12 +15,12 @@ function parse_commandline()
             help = "Input file"
             required = true
         "--path", "-p"
-                help = "Path for the output files [default: execution directory]"
-                arg_type = String
-                default = ""
+            help = "Path for the output files [default: execution directory]"
+            arg_type = String
+            default = ""
         "--progress"
-                help = "Display the progress"
-                action = :store_true
+            help = "Display the progress"
+            action = :store_true
     end
 
     s.epilog = """
@@ -44,11 +44,13 @@ function main(input)
     id = "no_accessionumber"
 
     if Args["progress"]
-        thresh = filesize(input)
-        prog = ProgressThresh(thresh, "Bytes read:")
+        totalsize = filesize(input)
+        val = totalsize
+        prog = ProgressThresh(1, "Bytes remaining:")
     end
 
-    for line in eachline(infh)
+    while !eof(infh)
+        line = readline(infh)
         if length(line) > 7 && line[1:7] == "#=GF AC"
             id = get_n_words(line, 3)[3]
         end
@@ -63,7 +65,8 @@ function main(input)
             id = "no_accessionumber"
             empty!(lines)
             if Args["progress"]
-                update!(prog, prog.val + filesize(filename))
+                val -= filesize(filename)
+                ProgressMeter.update!(prog, val)
             end
         end
     end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -18,7 +18,7 @@ function parse_commandline()
             help = "Path for the output files [default: execution directory]"
             arg_type = String
             default = ""
-        "--progress"
+        "--hideprogress"
             help = "Display the progress"
             action = :store_true
     end
@@ -43,7 +43,7 @@ function main(input)
     lines = []
     id = "no_accessionumber"
 
-    if Args["progress"]
+    if !Args["hideprogress"]
         totalsize = filesize(input)
         val = 0
         prog = Progress(totalsize, 1)
@@ -53,7 +53,7 @@ function main(input)
     while !eof(infh)
         line = readline(infh)
         if length(line) > 7 && line[1:7] == "#=GF AC"
-            id = get_n_words(line, 3)[3]
+            id = get_n_words(String(chomp(line)), 3)[3]
         end
         push!(lines, line)
         if line == "//\n"
@@ -65,7 +65,7 @@ function main(input)
             close(outfh)
             id = "no_accessionumber"
             empty!(lines)
-            if Args["progress"]
+            if !Args["hideprogress"]
                 val += filesize(filename)
                 ProgressMeter.update!(prog, val)
             end

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -21,6 +21,7 @@ function parse_commandline()
         "--hide-progress"
                 help = "Hide the progress [default: true]"
                 action = :store_false
+                default = :store_true
     end
 
     s.epilog = """

--- a/scripts/SplitStockholm.jl
+++ b/scripts/SplitStockholm.jl
@@ -52,7 +52,6 @@ function main(input)
     end
 
 	for line in eachline(infh)
-        line = readline(infh)
 		if length(line) > 7 && line[1:7] == "#=GF AC"
 			id = get_n_words(line, 3)[3]
 		end
@@ -67,9 +66,11 @@ function main(input)
 			id = "no_accessionumber"
 			empty!(lines)
 		end
+
         if Args["progress"]:
             next!(prog)
         end
+
 	end
 	close(infh)
 end


### PR DESCRIPTION
This pull request is to address #40 

It was actually a little tricky to find a way to determine the file size because `seekend(file)` is not supported by GZip.jl. However the trick on lines 48-50 seems to work and does not seem too slow.