### PR TITLE
Replace Array{T,1} with Vector{1}

### DIFF
--- a/src/MSA/Alphabet.jl
+++ b/src/MSA/Alphabet.jl
@@ -43,8 +43,8 @@ julia> ab[Residue('K')]
 ```
 """
 struct ReducedAlphabet <: ResidueAlphabet
-    mapping::Array{Int,1} # Residue -> Int
-    named::NamedArray{Int,1,Array{Int,1},Tuple{OrderedDict{String,Int}}}
+    mapping::Vector{Int} # Residue -> Int
+    named::NamedArray{Int,1,Vector{Int},Tuple{OrderedDict{String,Int}}}
     len::Int
 end
 
@@ -186,7 +186,7 @@ Base.names(alphabet::ResidueAlphabet) = String[ string(Residue(i)) for i in alph
 # Dict of names to indexes
 # ------------------------
 
-@inline _getdict(n::NamedArray{Int,1,Array{Int,1},Tuple{OrderedDict{String,Int}}}) = n.dicts[1]
+@inline _getdict(n::NamedArray{Int,1,Vector{Int},Tuple{OrderedDict{String,Int}}}) = n.dicts[1]
 
 const _UngappedAlphabet_Names = OrderedDict{String,Int}(string(Residue(i))=>i for i in 1:20)
 const _GappedAlphabet_Names = OrderedDict{String,Int}(string(Residue(i))=>i for i in 1:21)

--- a/src/MSA/Clusters.jl
+++ b/src/MSA/Clusters.jl
@@ -10,7 +10,7 @@ struct NoClustering <: ClusteringResult end
 @auto_hash_equals struct Clusters <: ClusteringResult
     clustersize::Vector{Int}
     clusters::Vector{Int}
-    weights::StatsBase.Weights{Float64, Float64, Array{Float64,1}}
+    weights::StatsBase.Weights{Float64, Float64, Vector{Float64}}
 end
 
 nelements(cl::Clusters) = length(cl.clusters)

--- a/src/MSA/GeneralParserMethods.jl
+++ b/src/MSA/GeneralParserMethods.jl
@@ -23,7 +23,7 @@ function _fill_aln_seq_ann!(aln, seq_ann::Vector{String}, seq::String,
     join(seq_ann, ','), init - 1
 end
 
-function _to_msa_mapping(sequences::Array{String,1})
+function _to_msa_mapping(sequences::Vector{String})
     nseq = size(sequences,1)
     nres = length(sequences[1])
     aln = Array{Residue}(undef, nres, nseq)
@@ -39,7 +39,7 @@ function _to_msa_mapping(sequences::Array{String,1})
     (msa, mapp)
 end
 
-function _to_msa_mapping(sequences::Array{String,1}, ids)
+function _to_msa_mapping(sequences::Vector{String}, ids)
     nseq = size(sequences,1)
     nres = length(sequences[1])
     aln = Array{Residue}(undef, nres, nseq)

--- a/src/MSA/Residues.jl
+++ b/src/MSA/Residues.jl
@@ -237,7 +237,7 @@ end
 
 Base.String(seq::Vector{Residue}) = convert(String, seq)
 
-function _get_msa_size(sequences::Array{String,1})
+function _get_msa_size(sequences::Vector{String})
     nseq = length(sequences)
     if nseq == 0
         throw(ErrorException("There are not sequences."))
@@ -246,7 +246,7 @@ function _get_msa_size(sequences::Array{String,1})
     nseq, nres
 end
 
-function _convert_to_matrix_residues(sequences::Array{String,1}, size::Tuple{Int,Int})
+function _convert_to_matrix_residues(sequences::Vector{String}, size::Tuple{Int,Int})
    nseq, nres = size
    aln = Array{Residue}(undef, nseq, nres)
    @inbounds for (i, str) in enumerate(sequences)
@@ -259,7 +259,7 @@ end
 
 # For convert a MSA stored as Vector{String} to Matrix{Residue}
 # This checks that all the sequences have the same length
-function Base.convert(::Type{Matrix{Residue}}, sequences::Array{String,1})
+function Base.convert(::Type{Matrix{Residue}}, sequences::Vector{String})
     nseq, nres = _get_msa_size(sequences)
     # throw() can be used with @threads : https://github.com/JuliaLang/julia/issues/17532
     for seq in sequences

--- a/src/SIFTS/ResidueMapping.jl
+++ b/src/SIFTS/ResidueMapping.jl
@@ -197,13 +197,13 @@ following fields that you can access at any moment for query purposes:
     UniProt::Union{dbUniProt,Missing}
     Pfam::Union{dbPfam,Missing}
     NCBI::Union{dbNCBI,Missing}
-    InterPro::Array{dbInterPro,1}
+    InterPro::Vector{dbInterPro}
     PDB::Union{dbPDB,Missing}
     SCOP::Union{dbSCOP,Missing}
-    SCOP2::Array{dbSCOP2,1}
+    SCOP2::Vector{dbSCOP2}
     SCOP2B::Union{dbSCOP2B,Missing}
     CATH::Union{dbCATH,Missing}
-    Ensembl::Array{dbEnsembl,1}
+    Ensembl::Vector{dbEnsembl}
     # residueDetail
     missing::Bool  # XML: <residueDetail dbSource="PDBe" property="Annotation" ...
     sscode::String # XML: <residueDetail dbSource="PDBe" property="codeSecondaryStructure"...


### PR DESCRIPTION
Hi! I'm working on a linter, and saw that this repository has [12 occurrences](https://lint.huijzer.xyz/github/diegozea/mitos.jl/#replace_arrayt1_with_vectort_12_hits) of using
```
Array{T,1}
```
where this could be shortened to
```
Vector{T}
```
I know that it doesn't shorten the code too much, but I think that overall it does improve the readability, and that is why I open this PR :smile: 

Feel free to close this PR immediately if you're not interested in this small refactoring.

By the way, the tests fail locally on
```
RESTful PDB Interface: Test Failed at /home/rik/git/MIT_orig/test/PDB/PDB.jl:276
  Expression: (getpdbdescription("104D"))["resolution"]
```
with and without applying this PR