### PR TITLE
`superimpose` chosen residues

### DIFF
--- a/test/PDB/Kabsch.jl
+++ b/test/PDB/Kabsch.jl
@@ -116,6 +116,12 @@
 
         @test isapprox(rα, 0.230, atol=0.001) # Bio3D RMSD
 
+        _, _, rα2 = superimpose(α1, α2, zip(1:length(α1), 1:length(α2)))
+        @test rα2 == rα
+
+        _, _, rα2 = superimpose(α1, α2, zip(1:2, 1:2))
+        @test rα2 < rα/10  # aligning only 2 points is accurate
+
         b1, b2, rβ = superimpose(β1, β2)
 
         @test isapprox(rβ, 0.251, atol=0.001) # Bio3D & Chimera's MatchMaker RMSD


### PR DESCRIPTION
If one wants to superimpose two different proteins with the Kabsch
algorithm, it is necessary to pick particular pairings of residues
to align. This adds an extra argument to `superimpose` that
allows specification of the particular pairings.
This only affects computation of the transformation; the
entire structure gets transformed.