### PR TITLE
Revert "CI: Do not test Julia 1.0"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         version:
           - '1.6' # LTS
+          - '1' # Latest Stable Release
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
This reverts commit 715a90a1ff484dd225c2971ada1059340d2362b6.

'1' means "latest stable release" (currently Julia 1.10), not "1.0".
'1.0' was already removed in #74.