### PR TITLE
Add sum_of_pairs_score for MSA

### DIFF
--- a/src/MSA/MSA.jl
+++ b/src/MSA/MSA.jl
@@ -138,6 +138,7 @@ export  # Residue
     percentidentity,
     meanpercentidentity,
     percentsimilarity,
+    sum_of_pairs_score,
     # Clusters
     WeightTypes,
     NoClustering,
@@ -172,6 +173,7 @@ include("MultipleSequenceAlignment.jl")
 include("MSAEditing.jl")
 include("GetIndex.jl")
 include("MSAStats.jl")
+include("MSAQuality.jl")
 include("GeneralParserMethods.jl")
 include("Raw.jl")
 include("Stockholm.jl")

--- a/src/MSA/MSAQuality.jl
+++ b/src/MSA/MSAQuality.jl
@@ -1,0 +1,102 @@
+const _BLOSUM62_DATA = Int[
+    #    A   R   N   D   C   Q   E   G   H   I   L   K   M   F   P   S   T   W   Y   V   -   X
+    4  -1  -2  -2   0  -1  -1   0  -2  -1  -1  -1  -1  -2  -1   1   0  -3  -2   0  -4  -1
+   -1   5   0  -2  -3   1   0  -2   0  -3  -2   2  -1  -3  -2  -1  -1  -3  -2  -3  -4  -1
+   -2   0   6   1  -3   0   0   0   1  -3  -3   0  -2  -3  -2   1   0  -4  -2  -3  -4  -1
+   -2  -2   1   6  -3   0   2  -1  -1  -3  -4  -1  -3  -3  -1   0  -1  -4  -3  -3  -4  -1
+    0  -3  -3  -3   9  -3  -4  -3  -3  -1  -1  -3  -1  -2  -3  -1  -1  -2  -2  -1  -4  -1
+   -1   1   0   0  -3   5   2  -2   0  -3  -2   1   0  -3  -1   0  -1  -2  -1  -2  -4  -1
+   -1   0   0   2  -4   2   5  -2   0  -3  -3   1  -2  -3  -1   0  -1  -3  -2  -2  -4  -1
+    0  -2   0  -1  -3  -2  -2   6  -2  -4  -4  -2  -3  -3  -2   0  -2  -2  -3  -3  -4  -1
+   -2   0   1  -1  -3   0   0  -2   8  -3  -3  -1  -2  -1  -2  -1  -2  -2   2  -3  -4  -1
+   -1  -3  -3  -3  -1  -3  -3  -4  -3   4   2  -3   1   0  -3  -2  -1  -3  -1   3  -4  -1
+   -1  -2  -3  -4  -1  -2  -3  -4  -3   2   4  -2   2   0  -3  -2  -1  -2  -1   1  -4  -1
+   -1   2   0  -1  -3   1   1  -2  -1  -3  -2   5  -1  -3  -1   0  -1  -3  -2  -2  -4  -1
+   -1  -1  -2  -3  -1   0  -2  -3  -2   1   2  -1   5   0  -2  -1  -1  -1  -1   1  -4  -1
+   -2  -3  -3  -3  -2  -3  -3  -3  -1   0   0  -3   0   6  -4  -2  -2   1   3  -1  -4  -1
+   -1  -2  -2  -1  -3  -1  -1  -2  -2  -3  -3  -1  -2  -4   7  -1  -1  -4  -3  -2  -4  -1
+    1  -1   1   0  -1   0   0   0  -1  -2  -2   0  -1  -2  -1   4   1  -3  -2  -2  -4  -1
+    0  -1   0  -1  -1  -1  -1  -2  -2  -1  -1  -1  -1  -2  -1   1   5  -2  -2   0  -4  -1
+   -3  -3  -4  -4  -2  -2  -3  -2  -2  -3  -2  -3  -1   1  -4  -3  -2  11   2  -3  -4  -1
+   -2  -2  -2  -3  -2  -1  -2  -3   2  -1  -1  -2  -1   3  -3  -2  -2   2   7  -1  -4  -1
+    0  -3  -3  -3  -1  -2  -2  -3  -3   3   1  -2   1  -1  -2  -2   0  -3  -1   4  -4  -1
+   -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4   1  -4
+   -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -4  -1
+] # 22x22
+
+const BLOSUM62_SCORE = _BLOSUM62_DATA
+
+function _pairwise_score(
+    seq1::AbstractVector{Residue},
+    seq2::AbstractVector{Residue};
+    gap_open::Int,
+    gap_extend::Int,
+    matrix::AbstractMatrix{Int} = BLOSUM62_SCORE,
+)
+    len = length(seq1)
+    score = 0
+    ingap1 = false
+    ingap2 = false
+    @inbounds for k = 1:len
+        r1 = seq1[k]
+        r2 = seq2[k]
+        if r1 == GAP && r2 == GAP
+            continue
+        elseif r1 == GAP
+            if ingap1
+                score += gap_extend
+            else
+                score += gap_open
+                ingap1 = true
+            end
+            ingap2 = false
+        elseif r2 == GAP
+            if ingap2
+                score += gap_extend
+            else
+                score += gap_open
+                ingap2 = true
+            end
+            ingap1 = false
+        else
+            ingap1 = false
+            ingap2 = false
+            score += matrix[Int(r1), Int(r2)]
+        end
+    end
+    score
+end
+
+"""
+    sum_of_pairs_score(msa; gap_open=-10, gap_extend=-1, matrix=BLOSUM62_SCORE)
+
+Calculate the sum-of-pairs score of an alignment using a substitution matrix.
+By default, the BLOSUM62 matrix is used. The penalties for gap opening and
+extension can be adjusted with the `gap_open` and `gap_extend` keyword
+arguments. Pass a different `matrix` to use another substitution scheme.
+"""
+function sum_of_pairs_score(
+    msa::AbstractMatrix{Residue};
+    gap_open::Int = -10,
+    gap_extend::Int = -1,
+    matrix::AbstractMatrix{Int} = BLOSUM62_SCORE,
+)
+    nseq, _ = size(msa)
+    total = 0
+    @inbounds for i = 1:(nseq-1)
+        seqi = view(msa, i, :)
+        for j = (i+1):nseq
+            total += _pairwise_score(
+                seqi,
+                view(msa, j, :);
+                gap_open = gap_open,
+                gap_extend = gap_extend,
+                matrix = matrix,
+            )
+        end
+    end
+    total
+end
+
+sum_of_pairs_score(msa::AbstractAlignedObject; kargs...) =
+    sum_of_pairs_score(namedmatrix(msa); kargs...)

--- a/test/MSA/MSAQuality.jl
+++ b/test/MSA/MSAQuality.jl
@@ -1,0 +1,66 @@
+@testset "MSAQuality" begin
+    import MIToS.MSA: _pairwise_score
+
+    @testset "Sum Of Pairs" begin
+        simple = read_file(joinpath(DATA, "simple.fasta"), FASTA)
+        expected_simple = _pairwise_score(simple[1, :], simple[2, :];
+            gap_open = -10,
+            gap_extend = -1,
+        )
+        @test sum_of_pairs_score(simple) == expected_simple
+
+        msa = permutedims(hcat(res"A-", res"AR", res"RA"))
+        expected_default = _pairwise_score(msa[1, :], msa[2, :];
+            gap_open = -10,
+            gap_extend = -1,
+        ) +
+        _pairwise_score(msa[1, :], msa[3, :];
+            gap_open = -10,
+            gap_extend = -1,
+        ) +
+        _pairwise_score(msa[2, :], msa[3, :];
+            gap_open = -10,
+            gap_extend = -1,
+        )
+        @test sum_of_pairs_score(msa) == expected_default
+
+        expected_custom = _pairwise_score(msa[1, :], msa[2, :];
+            gap_open = -5,
+            gap_extend = -2,
+        ) +
+        _pairwise_score(msa[1, :], msa[3, :];
+            gap_open = -5,
+            gap_extend = -2,
+        ) +
+        _pairwise_score(msa[2, :], msa[3, :];
+            gap_open = -5,
+            gap_extend = -2,
+        )
+        @test sum_of_pairs_score(msa; gap_open = -5, gap_extend = -2) == expected_custom
+
+        custom_matrix = fill(-1, 22, 22)
+        for i in 1:22
+            custom_matrix[i, i] = 1
+        end
+        expected_matrix = _pairwise_score(msa[1, :], msa[2, :];
+            gap_open = -5,
+            gap_extend = -2,
+            matrix = custom_matrix,
+        ) +
+        _pairwise_score(msa[1, :], msa[3, :];
+            gap_open = -5,
+            gap_extend = -2,
+            matrix = custom_matrix,
+        ) +
+        _pairwise_score(msa[2, :], msa[3, :];
+            gap_open = -5,
+            gap_extend = -2,
+            matrix = custom_matrix,
+        )
+        @test sum_of_pairs_score(msa; gap_open = -5, gap_extend = -2, matrix = custom_matrix) == expected_matrix
+
+        g1 = res"-A-"
+        g2 = res"A--"
+        @test _pairwise_score(g1, g2; gap_open = -10, gap_extend = -1) == -20
+    end
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -43,6 +43,7 @@ end
     include("MSA/General.jl")
     include("MSA/MSAEditing.jl")
     include("MSA/MSAStats.jl")
+    include("MSA/MSAQuality.jl")
     include("MSA/Sequences.jl")
     include("MSA/Shuffle.jl")
     include("MSA/Identity.jl")


### PR DESCRIPTION
## Summary
- embed full BLOSUM62 matrix and expose it as `BLOSUM62_SCORE`
- allow custom substitution matrices for `_pairwise_score` and `sum_of_pairs_score`
- rename the new testset to `Sum Of Pairs` and add custom matrix tests

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("MSAQuality")'`

------
https://chatgpt.com/codex/tasks/task_b_6840bfee53a0832d8ba48f2d82e149fe