### PR TITLE
Improve PDBResidue display

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
   which omit occupancy or B-factor values. The parser now defaults missing
   occupancy to `1.0` and B-factor to `"0.0"`. A single warning informs when
   occupancy values are not present.
+- Improved `show` method for `PDBResidue` so that atom headers are printed only once
+  per residue, reducing the output length. The index column has been removed for a
+  more compact display.
 
 ### Changes from v3.0.6 to v3.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,8 @@
   occupancy to `1.0` and B-factor to `"0.0"`. A single warning informs when
   occupancy values are not present.
 - Improved `show` method for `PDBResidue` so that atom headers are printed only once
-  per residue, reducing the output length. The index column has been removed for a
-  more compact display.
+  per residue. The index column was removed, indentation reduced to two spaces, and
+  atom columns are now narrower for a more compact display.
 
 ### Changes from v3.0.6 to v3.1.0
 

--- a/src/PDB/PDBResidues.jl
+++ b/src/PDB/PDBResidues.jl
@@ -975,9 +975,8 @@ end
 const _Format_ResidueID = FormatExpr("{:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
 const _Format_ATOM = FormatExpr("{:>50} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
 
-const _Format_ResidueID_Res = FormatExpr("\t\t{:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
-const _Format_ATOM_Res =
-    FormatExpr("\t\t{:>50} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
+const _Format_ResidueID_Res = FormatExpr("  {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
+const _Format_ATOM_Res = FormatExpr("  {:>25} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}\n")
 
 function Base.show(io::IO, id::PDBResidueIdentifier)
     printfmt(
@@ -1028,7 +1027,7 @@ function Base.show(io::IO, atom::PDBAtom)
 end
 
 function Base.show(io::IO, res::PDBResidue)
-    println(io, "PDBResidue:\n\tid::PDBResidueIdentifier")
+    println(io, "PDBResidue:\n  id::PDBResidueIdentifier")
     printfmt(
         io,
         _Format_ResidueID_Res,
@@ -1050,7 +1049,7 @@ function Base.show(io::IO, res::PDBResidue)
         string('"', res.id.chain, '"'),
     )
     len = length(res)
-    println(io, "\tatoms::Vector{PDBAtom}\tlength: ", len)
+    println(io, "  atoms::Vector{PDBAtom}  length: ", len)
     printfmt(
         io,
         _Format_ATOM_Res,

--- a/src/PDB/PDBResidues.jl
+++ b/src/PDB/PDBResidues.jl
@@ -977,7 +977,7 @@ const _Format_ATOM = FormatExpr("{:>50} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15
 
 const _Format_ResidueID_Res = FormatExpr("\t\t{:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
 const _Format_ATOM_Res =
-    FormatExpr("\t\t{:<10} {:>50} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
+    FormatExpr("\t\t{:>50} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}\n")
 
 function Base.show(io::IO, id::PDBResidueIdentifier)
     printfmt(
@@ -1051,23 +1051,21 @@ function Base.show(io::IO, res::PDBResidue)
     )
     len = length(res)
     println(io, "\tatoms::Vector{PDBAtom}\tlength: ", len)
+    printfmt(
+        io,
+        _Format_ATOM_Res,
+        "coordinates",
+        "atom",
+        "element",
+        "occupancy",
+        "B",
+        "alt_id",
+        "charge",
+    )
     for i = 1:len
         printfmt(
             io,
             _Format_ATOM_Res,
-            "",
-            "coordinates",
-            "atom",
-            "element",
-            "occupancy",
-            "B",
-            "alt_id",
-            "charge",
-        )
-        printfmt(
-            io,
-            _Format_ATOM_Res,
-            string(i, ":"),
             res.atoms[i].coordinates,
             string('"', res.atoms[i].atom, '"'),
             string('"', res.atoms[i].element, '"'),


### PR DESCRIPTION
## Summary
- show atom headers only once per PDBResidue so output is shorter
- remove the index column from the atom display
- update NEWS about the compact display

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using Pkg; Pkg.instantiate(); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'`
- `julia --project -e 'using Pkg; Pkg.test(coverage=true)'` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_684feef3953c832d9d6a859b3e5f04b2