### PR TITLE
Add keyword constructors for PDBResidue types

### DIFF
--- a/src/PDB/PDBResidues.jl
+++ b/src/PDB/PDBResidues.jl
@@ -68,6 +68,25 @@ following fields that you can access at any moment for query purposes:
     atoms::Vector{PDBAtom}
 end
 
+# Constructors to match printed representation
+function PDBResidueIdentifier(; PDB_number, number, name, group, model, chain)
+    PDBResidueIdentifier(PDB_number, number, name, group, model, chain)
+end
+
+function Coordinates(a::AbstractVector{<:Real})
+    length(a) == 3 || throw(ArgumentError("Coordinates vector must have length 3"))
+    Coordinates((a[1], a[2], a[3]))
+end
+
+function PDBAtom(; coordinates, atom, element, occupancy, B, alt_id, charge)
+    coords = coordinates isa Coordinates ? coordinates : Coordinates(coordinates)
+    PDBAtom(coords, atom, element, occupancy, B, alt_id, charge)
+end
+
+function PDBResidue(; id, atoms)
+    PDBResidue(id, atoms)
+end
+
 Base.length(res::PDBResidue) = length(res.atoms)
 
 # Copy

--- a/test/PDB/ShowConstructors.jl
+++ b/test/PDB/ShowConstructors.jl
@@ -1,0 +1,16 @@
+@testset "Show constructors" begin
+    pdbfile = joinpath(DATA, "short.pdb")
+    res = read_file(pdbfile, PDBFile)[1]
+
+    id_str = sprint(show, res.id)
+    id = eval(Meta.parse(id_str))
+    @test id == res.id
+
+    atom_str = sprint(show, res.atoms[1])
+    atom = eval(Meta.parse(atom_str))
+    @test atom == res.atoms[1]
+
+    res_str = sprint(show, res)
+    new_res = eval(Meta.parse(res_str))
+    @test new_res == res
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -74,6 +74,7 @@ end
     include("PDB/Sequences.jl")
     include("PDB/AlphaFoldDB.jl")
     include("PDB/ShortPDB.jl")
+    include("PDB/ShowConstructors.jl")
 end
 
 # SIFTS


### PR DESCRIPTION
## Summary
- provide keyword constructors for PDBResidueIdentifier, PDBAtom, and PDBResidue
- allow building Coordinates from vectors
- test reconstruction of PDB objects using their printed representation

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'`

------
https://chatgpt.com/codex/tasks/task_b_68503561eb38832d9db965655d8e9149