### PR TITLE
Add function-first filtering methods

### DIFF
--- a/docs/src/MSA.md
+++ b/docs/src/MSA.md
@@ -184,12 +184,12 @@ names end with a bang `!`, following the Julia convention. Some of these functio
 `annotate` keyword argument (in general, it's `true` by default) to indicate if the
 modification should be recorded in the MSA/sequence annotations.
 
-One common task is to delete sequences or columns of the MSA. This could be done using the
-functions `filtersequences!` and `filtercolumns!`. These functions take the MSA or sequence
-(if it's possible) as first argument and a `BitVector` or `Vector{Bool}` mask as second
-argument. It deletes all the sequences or columns where the mask is `false`. These functions
-are also defined for `Annotations`, this allows to automatically update (modify) the
-annotations (and therefore, sequence and column mappings) in the MSA.
+One common task is to delete sequences or columns of the MSA using the functions
+`filtersequences!` and `filtercolumns!`. They take the MSA as the first argument and either a
+boolean mask or a function as the second argument. You may also provide the function first,
+which enables the `do` block syntax. Elements for which the result is `false` are deleted. These
+functions are also defined for `Annotations`, allowing automatic updates of the annotations and
+the sequence and column mappings in the MSA.
 
 This two deleting operations are used in the second and third mutating
 functions of the following list:

--- a/src/MSA/MSAEditing.jl
+++ b/src/MSA/MSAEditing.jl
@@ -105,10 +105,12 @@ filtersequences(msa::AbstractMatrix{Residue}, mask) = msa[_sequence_mask(mask, m
 
 """
 `filtersequences!(msa, mask[, annotate::Bool=true])`
+`filtersequences!(f, msa[, annotate::Bool=true])`
 
-It allows to filter `msa` sequences using a `AbstractVector{Bool}` `mask`
-(It removes sequences with `false` values). `AnnotatedMultipleSequenceAlignment` annotations
-are updated if `annotate` is `true` (default).
+It allows to filter `msa` sequences using a boolean `mask` or a function `f`
+(called once per sequence). Sequences with `false` values are removed.
+`AnnotatedMultipleSequenceAlignment` annotations are updated if `annotate`
+is `true` (default).
 """
 function filtersequences!(
     msa::AnnotatedMultipleSequenceAlignment,
@@ -131,6 +133,23 @@ function filtersequences!(msa::MultipleSequenceAlignment, mask, annotate::Bool =
     msa
 end
 
+# Wrapper to support do-block syntax: the function comes first
+function filtersequences!(
+    f::Function,
+    msa::AnnotatedMultipleSequenceAlignment,
+    annotate::Bool = true,
+)
+    filtersequences!(msa, f, annotate)
+end
+
+function filtersequences!(
+    f::Function,
+    msa::MultipleSequenceAlignment,
+    annotate::Bool = false,
+)
+    filtersequences!(msa, f, annotate)
+end
+
 function filtersequences(
     msa::Union{AnnotatedMultipleSequenceAlignment,MultipleSequenceAlignment},
     args...,
@@ -150,9 +169,11 @@ end
 
 """
 `filtercolumns!(msa, mask[, annotate::Bool=true])`
+`filtercolumns!(f, msa[, annotate::Bool=true])`
 
-It allows to filter MSA or aligned sequence columns/positions using a
-`AbstractVector{Bool}` `mask`. Annotations are updated if `annotate` is `true` (default).
+It allows to filter MSA or aligned sequence columns/positions using a boolean
+`mask` or a function `f` applied to each column. Annotations are updated if
+`annotate` is `true` (default).
 """
 function filtercolumns!(
     x::Union{AnnotatedMultipleSequenceAlignment,AnnotatedAlignedSequence,AnnotatedSequence},
@@ -172,6 +193,19 @@ function filtercolumns!(x::UnannotatedAlignedObject, mask, annotate::Bool = fals
     # inside other functions
     x.matrix = filtercolumns(namedmatrix(x), _column_mask(mask, x))
     x
+end
+
+# Wrapper to support do-block syntax: the function comes first
+function filtercolumns!(
+    f::Function,
+    x::Union{AnnotatedMultipleSequenceAlignment,AnnotatedAlignedSequence,AnnotatedSequence},
+    annotate::Bool = true,
+)
+    filtercolumns!(x, f, annotate)
+end
+
+function filtercolumns!(f::Function, x::UnannotatedAlignedObject, annotate::Bool = false)
+    filtercolumns!(x, f, annotate)
 end
 
 filtercolumns(x::AbstractResidueMatrix, args...) = filtercolumns!(deepcopy(x), args...)

--- a/test/MSA/MSAEditing.jl
+++ b/test/MSA/MSAEditing.jl
@@ -61,6 +61,12 @@
             )
             @test_throws ArgumentError filtersequences(msa, [1, 2, 3] .> 2)
         end
+
+        for msa in pfam_msas[3:4]
+            copy_msa = copy(msa)
+            @test filtersequences!(seq -> gapfraction(seq) < 0.5, copy_msa) ==
+                  filtersequences(msa, seq -> gapfraction(seq) < 0.5)
+        end
     end
 
     @testset "filtercolumns!" begin
@@ -77,6 +83,12 @@
 
             @test_throws ArgumentError filtercolumns(msa, [1, 2, 3] .> 2)
             @test_throws ArgumentError filtercolumns(msa, collect(1:200) .<= 10)
+        end
+
+        for msa in pfam_msas[3:4]
+            copy_msa = copy(msa)
+            @test filtercolumns!(col -> gapfraction(col) < 0.5, copy_msa) ==
+                  filtercolumns(msa, col -> gapfraction(col) < 0.5)
         end
 
         @testset "filtercolumns! for sequences" begin
@@ -103,6 +115,9 @@
 
             @test getannotcolumn(filtered_annseq, "SS_cons") == "XHHEXXXXXXXXXX"
             @test getannotresidue(filtered_annseq, "SS") == "XHHEXXXXXXXXXX"
+
+            @test filtercolumns!(col -> col[1] == Residue('Q'), copy(annseq)) ==
+                  filtercolumns(annseq, col -> col[1] == Residue('Q'))
         end
     end
 


### PR DESCRIPTION
## Summary
- allow `filtercolumns!` and `filtersequences!` to accept a function as the first argument
- document do-block usage for these wrappers
- test new methods using do-block syntax

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("MSAEditing.jl")'`
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("MSAEditing.jl")'`

------
https://chatgpt.com/codex/tasks/task_b_685126654b3c832d9a9f16be00ea8ecb