### PR TITLE
Allow AbstractString IDs

### DIFF
--- a/src/MSA/MSAEditing.jl
+++ b/src/MSA/MSAEditing.jl
@@ -218,7 +218,7 @@ This function takes a vector of sequence names and a sequence id.
 It returns the position of that id in the vector.
 If the id isn't in the vector, It throws an error.
 """
-function _get_seqid_index(names::Vector{String}, sequence_id::String)
+function _get_seqid_index(names::Vector{String}, sequence_id::AbstractString)
     id_index = something(findfirst(isequal(sequence_id), names), 0)
     if id_index == 0
         throw(ErrorException("$sequence_id is not in the list of sequence names."))
@@ -255,7 +255,7 @@ function swapsequences!(matrix::NamedArray, i::Int, j::Int)
     return matrix
 end
 
-function swapsequences!(matrix::NamedArray, i::String, j::String)
+function swapsequences!(matrix::NamedArray, i::AbstractString, j::AbstractString)
     seqnames = sequencenames(matrix)
     swapsequences!(matrix, _get_seqid_index(seqnames, i), _get_seqid_index(seqnames, j))
 end
@@ -302,7 +302,7 @@ end
 
 function setreference!(
     msa::NamedResidueMatrix{T},
-    id::String,
+    id::AbstractString,
     annotate::Bool = false,
 ) where {T<:AbstractArray}
     swapsequences!(msa, names(msa, 1)[1], id)
@@ -310,7 +310,7 @@ end
 
 function setreference!(
     msa::AbstractMultipleSequenceAlignment,
-    id::String,
+    id::AbstractString,
     annotate::Bool = true,
 )
     setreference!(msa, _get_seqid_index(sequencenames(msa), id), annotate)

--- a/src/MSA/MultipleSequenceAlignment.jl
+++ b/src/MSA/MultipleSequenceAlignment.jl
@@ -484,7 +484,7 @@ getresiduesequences(x::AbstractResidueMatrix) = getresiduesequences(getresidues(
 # ---------------
 
 # Gives you the annotations of the Sequence
-function getsequence(data::Annotations, id::String)
+function getsequence(data::Annotations, id::AbstractString)
     GS = Dict{Tuple{String,String},String}()
     GR = Dict{Tuple{String,String},String}()
     if length(data.sequences) > 0
@@ -518,7 +518,8 @@ to the sequence.
 getsequence(msa::AbstractMatrix{Residue}, i::Int) = msa[i:i, :]
 
 getsequence(msa::NamedResidueMatrix{Array{Residue,2}}, i::Int) = msa[i:i, :]
-getsequence(msa::NamedResidueMatrix{Array{Residue,2}}, id::String) = msa[String[id], :]
+getsequence(msa::NamedResidueMatrix{Array{Residue,2}}, id::AbstractString) =
+    msa[String[id], :]
 
 function getsequence(msa::AnnotatedMultipleSequenceAlignment, i::Int)
     seq = namedmatrix(msa)[i:i, :]
@@ -526,13 +527,13 @@ function getsequence(msa::AnnotatedMultipleSequenceAlignment, i::Int)
     AnnotatedAlignedSequence(seq, annot)
 end
 
-function getsequence(msa::AnnotatedMultipleSequenceAlignment, id::String)
+function getsequence(msa::AnnotatedMultipleSequenceAlignment, id::AbstractString)
     seq = namedmatrix(msa)[String[id], :]
     annot = getsequence(annotations(msa), id)
     AnnotatedAlignedSequence(seq, annot)
 end
 
-function getsequence(msa::MultipleSequenceAlignment, seq::String)
+function getsequence(msa::MultipleSequenceAlignment, seq::AbstractString)
     AlignedSequence(getsequence(namedmatrix(msa), seq))
 end
 
@@ -815,7 +816,7 @@ It returns the sequence coordinates as a `Vector{Int}` for an MSA sequence. That
 one element for each MSA column. If the number if `0` in the mapping, there is a gap in
 that column for that sequence.
 """
-function getsequencemapping(msa::AnnotatedMultipleSequenceAlignment, seq_id::String)
+function getsequencemapping(msa::AnnotatedMultipleSequenceAlignment, seq_id::AbstractString)
     _str2int_mapping(getannotsequence(msa, seq_id, "SeqMap"))
 end
 

--- a/src/MSA/PIR.jl
+++ b/src/MSA/PIR.jl
@@ -102,7 +102,7 @@ function _print_pir_seq(io::IO, seq_type, seq_id, seq_title, seq)
     println(io, '*')
 end
 
-function _get_pir_annotations(sequence_annotations, seq_id::String)
+function _get_pir_annotations(sequence_annotations, seq_id::AbstractString)
     if haskey(sequence_annotations, (seq_id, "Type"))
         seq_type = sequence_annotations[(seq_id, "Type")]
     else

--- a/src/PDB/AlphaFoldDB.jl
+++ b/src/PDB/AlphaFoldDB.jl
@@ -5,7 +5,7 @@ This function queries the AlphaFoldDB API to retrieve structure information for
 a given `uniprot_accession`, e.g. `"P00520"`. This function returns the structure
 information as a `JSON3.Object`.
 """
-function query_alphafolddb(uniprot_accession::String)
+function query_alphafolddb(uniprot_accession::AbstractString)
     # Construct the URL for the AlphaFoldDB API request
     url = "https://alphafold.ebi.ac.uk/api/prediction/$uniprot_accession"
 
@@ -26,13 +26,13 @@ function query_alphafolddb(uniprot_accession::String)
 end
 
 # This function extracts the filename from a given URL.
-function _extract_filename_from_url(url::String)
+function _extract_filename_from_url(url::AbstractString)
     return split(url, "/")[end]
 end
 
 # Function to download the PDB or CIF file based on the UniProt Accession
 """
-    download_alphafold_structure(uniprot_accession::String; format::Type{T}=MMCIFFile) where T<:FileFormat
+    download_alphafold_structure(uniprot_accession::AbstractString; format::Type{T}=MMCIFFile) where T<:FileFormat
 
 This function downloads the structure file (PDB or mmCIF) for a given UniProt Accession
 from AlphaFoldDB. The `uniprot_accession` parameter specifies the UniProt Accession of the

--- a/src/PDB/PDBMLParser.jl
+++ b/src/PDB/PDBMLParser.jl
@@ -179,10 +179,10 @@ This function calls `MIToS.Utils.download_file` that calls `Downloads.download`.
 can use keyword arguments, such as `headers`, from that function.
 """
 function downloadpdb(
-    pdbcode::String;
+    pdbcode::AbstractString;
     format::Type{T} = MMCIFFile,
-    filename::String = uppercase(pdbcode) * _file_extension(format),
-    baseurl::String = "http://www.rcsb.org/pdb/files/",
+    filename::AbstractString = uppercase(pdbcode) * _file_extension(format),
+    baseurl::AbstractString = "http://www.rcsb.org/pdb/files/",
     kargs...,
 ) where {T<:FileFormat}
     if check_pdbcode(pdbcode)
@@ -205,7 +205,7 @@ end
 
 This function use the percent-encoding to escape the characters that are not allowed in a URL.
 """
-function _escape_url_query(query::String)::String
+function _escape_url_query(query::AbstractString)::String
     # Characters that do not need to be percent-encoded
     unreserved =
         Set{Char}("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~")
@@ -223,7 +223,7 @@ function _escape_url_query(query::String)::String
     String(take!(encoded_url))
 end
 
-function _graphql_query(pdbcode::String)
+function _graphql_query(pdbcode::AbstractString)
     """
     {
       entry(entry_id: "$pdbcode") {
@@ -252,7 +252,7 @@ function _graphql_query(pdbcode::String)
     """ |> _escape_url_query
 end
 
-function _pdbheader(pdbcode::String; kargs...)
+function _pdbheader(pdbcode::AbstractString; kargs...)
     pdbcode = uppercase(pdbcode)
     if check_pdbcode(pdbcode)
         with_logger(ConsoleLogger(stderr, Logging.Warn)) do
@@ -273,7 +273,11 @@ end
 """
 It downloads a JSON file containing the PDB header information.
 """
-function downloadpdbheader(pdbcode::String; filename::String = tempname(), kargs...)
+function downloadpdbheader(
+    pdbcode::AbstractString;
+    filename::AbstractString = tempname(),
+    kargs...,
+)
     open(filename, "w") do fh
         write(fh, _pdbheader(pdbcode; kargs...))
     end
@@ -285,6 +289,6 @@ Access general information about a PDB entry (e.g., Header information) using th
 GraphQL interface of the PDB database. It parses the JSON answer into a `JSON3.Object` that
 can be used as a dictionary.
 """
-function getpdbdescription(pdbcode::String; kargs...)
+function getpdbdescription(pdbcode::AbstractString; kargs...)
     JSON3.read(_pdbheader(pdbcode; kargs...))["data"]["entry"]
 end

--- a/src/SIFTS/XMLParser.jl
+++ b/src/SIFTS/XMLParser.jl
@@ -4,7 +4,7 @@ struct SIFTSXML <: FileFormat end
 # ==============
 
 """
-    downloadsifts(pdbcode::String; filename::String, source::String="https")
+    downloadsifts(pdbcode::AbstractString; filename::AbstractString, source::AbstractString="https")
 
 Download the gzipped SIFTS XML file for the provided `pdbcode`.
 The downloaded file will have the default extension `.xml.gz`.
@@ -17,9 +17,9 @@ This option will download the file from the
 EBI PDBe server at https://www.ebi.ac.uk/pdbe/files/sifts/.
 """
 function downloadsifts(
-    pdbcode::String;
-    filename::String = "$(lowercase(pdbcode)).xml.gz",
-    source::String = "https",
+    pdbcode::AbstractString;
+    filename::AbstractString = "$(lowercase(pdbcode)).xml.gz",
+    source::AbstractString = "https",
 )
     @argcheck endswith(filename, ".xml.gz") "filename must end with .xml.gz"
     @argcheck source == "ftp" || source == "https" "source must be ftp or https"

--- a/src/Utils/GeneralUtils.jl
+++ b/src/Utils/GeneralUtils.jl
@@ -3,7 +3,7 @@ All is used instead of MIToS 1.0 "all" or "*", because it's possible to dispatch
 """
 struct All end
 
-_get_function_name(str::String)::String = split(str, '.')[end]
+_get_function_name(str::AbstractString)::String = split(str, '.')[end]
 
 """
 This function performs the same operation as
@@ -84,7 +84,10 @@ Selects the first element of the vector. This is useful for unpacking one elemen
 Throws a warning if there are more elements. `element_name` is *element* by default,
 but the name can be changed using the second argument.
 """
-function select_element(vector::Array{T,1}, element_name::String = "element") where {T}
+function select_element(
+    vector::Array{T,1},
+    element_name::AbstractString = "element",
+) where {T}
     len = length(vector)
     if len == 0
         throw(ErrorException("There is not $element_name"))
@@ -159,7 +162,7 @@ end
 """
 It checks if a PDB code has the correct format.
 """
-check_pdbcode(pdbcode::String) = occursin(r"^\w{4}$", pdbcode)
+check_pdbcode(pdbcode::AbstractString) = occursin(r"^\w{4}$", pdbcode)
 
 """
 Getter for the `array` field of `NamedArray`s


### PR DESCRIPTION
## Summary
- generalize `_get_seqid_index` and swapping helpers to accept `AbstractString`
- relax `setreference!` ID arguments
- update sequence retrieval and mapping functions to accept `AbstractString`
- make PDB utilities accept `AbstractString` identifiers
- loosen SIFTS download types
- loosen helper utilities like `check_pdbcode`
- keep `get_n_words` signature as `String`

## Testing
- `julia --project -e 'using Pkg; Pkg.test(coverage=true)'` *(fails: RequestError to ftp.ebi.ac.uk)*

------
https://chatgpt.com/codex/tasks/task_b_685174d8b4c0832dac8b6b29a16e0b62