### PR TITLE
Fix Raw parser

### DIFF
--- a/src/MSA/Raw.jl
+++ b/src/MSA/Raw.jl
@@ -10,9 +10,13 @@ function _load_sequences(
 )
     SEQS = String[]
     IDS = String[]
+    nonres = r"[^A-Za-z-\.]+"
     for (i, line::String) in enumerate(lineiterator(io))
-        push!(SEQS, line)
-        push!(IDS, string(i))
+        clean = replace(line, nonres => "")
+        if !isempty(clean)
+            push!(SEQS, clean)
+            push!(IDS, string(i))
+        end
     end
     return IDS, SEQS, Annotations()
 end

--- a/test/MSA/IO.jl
+++ b/test/MSA/IO.jl
@@ -359,6 +359,15 @@
             end
 
             @test parse_file(raw_string, Raw) == raw
+
+            special_string = """# P D K Q L D E R E H T I E
+# P D A Q R I K A K R N A K"""
+            expected = parse_file(
+                """PDKQLDEREHTIE
+PDAQRIKAKRNAK""",
+                Raw,
+            )
+            @test parse_file(special_string, Raw) == expected
         end
 
         @testset "Print" begin


### PR DESCRIPTION
## Summary
- trim non-residue characters when parsing Raw MSA files
- test Raw parser with spaces and # comments

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("Raw")'`

------
https://chatgpt.com/codex/tasks/task_b_6851918d5814832dbd5fd22eb7300988