### PR TITLE
Add benchmarks & cleanup distance warmup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,5 +46,19 @@ in the `Project.toml` file. Each section in the `NEWS.md` has a title that indic
 previous and current versions. The last version should always be placed first in the 
 `NEWS.md` file, followed by older sections, ordered from most recent to oldest. Document 
 each change with bullet points. Clearly label breaking changes using 
-the `*[Breaking change]*` tag at the beginning of the bullet, so they are easily 
+the `*[Breaking change]*` tag at the beginning of the bullet, so they are easily
 identifiable.
+
+# Benchmarking
+
+If you are explicitly asked to run the benchmark suite, make sure
+`PkgBenchmark` and `BenchmarkTools` are installed. Then execute the
+following command from the repository root to tune and run all benchmarks:
+
+```bash
+julia --project -e 'import PkgBenchmark, MIToS; PkgBenchmark.benchmarkpkg(MIToS; retune=true)'
+```
+
+This command creates a `benchmark/tune.json` file with the tuning
+information and prints benchmark results to the terminal.
+

--- a/benchmark/Information/Entropy.jl
+++ b/benchmark/Information/Entropy.jl
@@ -1,0 +1,11 @@
+let
+    data_dir = joinpath(@__DIR__, "..", "..", "test", "data")
+    msa_file = joinpath(data_dir, "PF09645_full.fasta.gz")
+    msa = read_file(msa_file, FASTA)
+    table = Probabilities{Float64,1,UngappedAlphabet}(
+        ContingencyTable(Float64, Val{1}, UngappedAlphabet()),
+    )
+
+    SUITE["Information"]["shannon_entropy"]["PF09645"] =
+        @benchmarkable mapcolfreq!(shannon_entropy, $msa, $table)
+end

--- a/benchmark/Information/HighLevel.jl
+++ b/benchmark/Information/HighLevel.jl
@@ -1,0 +1,7 @@
+let
+    msa_file = joinpath(@__DIR__, "..", "..", "test", "data", "Gaoetal2011.fasta")
+    msa = read_file(msa_file, FASTA)
+
+    SUITE["Information"]["highlevel"]["buslje09"] = @benchmarkable buslje09($msa)
+    SUITE["Information"]["highlevel"]["BLMI"] = @benchmarkable BLMI($msa)
+end

--- a/benchmark/Information/MIp.jl
+++ b/benchmark/Information/MIp.jl
@@ -1,0 +1,13 @@
+let
+    data_dir = joinpath(@__DIR__, "..", "..", "test", "data")
+    msa_file = joinpath(data_dir, "PF09645_full.fasta.gz")
+    msa = read_file(msa_file, FASTA, MultipleSequenceAlignment)
+    table = Counts{Float64,2,GappedAlphabet}(
+        ContingencyTable(Float64, Val{2}, GappedAlphabet()),
+    )
+
+    SUITE["Information"]["MIp"]["PF09645"] = @benchmarkable begin
+        mi = mapcolpairfreq!(mutual_information, $msa, $table)
+        APC!(mi)
+    end
+end

--- a/benchmark/MSA/Clustering.jl
+++ b/benchmark/MSA/Clustering.jl
@@ -1,0 +1,6 @@
+let
+    msa_file = joinpath(@__DIR__, "..", "..", "test", "data", "Gaoetal2011.fasta")
+    msa = read_file(msa_file, FASTA, MultipleSequenceAlignment)
+
+    SUITE["MSA"]["hobohmI"]["pid62"] = @benchmarkable hobohmI($msa, 62)
+end

--- a/benchmark/MSA/Identity.jl
+++ b/benchmark/MSA/Identity.jl
@@ -1,0 +1,8 @@
+let
+    msa_file = joinpath(@__DIR__, "..", "..", "test", "data", "Gaoetal2011.fasta")
+    msa = read_file(msa_file, FASTA, MultipleSequenceAlignment)
+
+    SUITE["MSA"]["identity"]["matrix_Float64"] =
+        @benchmarkable percentidentity($msa, Float64)
+    SUITE["MSA"]["identity"]["mean"] = @benchmarkable meanpercentidentity($msa)
+end

--- a/benchmark/MSA/Read.jl
+++ b/benchmark/MSA/Read.jl
@@ -1,0 +1,10 @@
+let
+    data_dir = joinpath(@__DIR__, "..", "..", "test", "data")
+    fasta_gz = joinpath(data_dir, "PF09645_full.fasta.gz")
+    sth = joinpath(data_dir, "PF09645_full.stockholm")
+
+    SUITE["MSA"]["read"]["Stockholm"] =
+        @benchmarkable read_file($sth, Stockholm, MultipleSequenceAlignment)
+    SUITE["MSA"]["read"]["FASTA.gz"] =
+        @benchmarkable read_file($fasta_gz, FASTA, MultipleSequenceAlignment)
+end

--- a/benchmark/MSA/Write.jl
+++ b/benchmark/MSA/Write.jl
@@ -1,0 +1,11 @@
+let
+    msa_file = joinpath(@__DIR__, "..", "..", "test", "data", "Gaoetal2011.fasta")
+    msa = read_file(msa_file, FASTA, MultipleSequenceAlignment)
+
+    SUITE["MSA"]["write"]["FASTA"] = @benchmarkable begin
+        (tmp, io) = mktemp()
+        close(io)
+        write_file(tmp, $msa, FASTA)
+        rm(tmp, force = true)
+    end
+end

--- a/benchmark/PDB/Count.jl
+++ b/benchmark/PDB/Count.jl
@@ -1,0 +1,7 @@
+let
+    pdb_file = joinpath(@__DIR__, "..", "..", "test", "data", "1CBN.pdb")
+    struc = read_file(pdb_file, PDBFile)
+
+    SUITE["PDB"]["count_alanine"]["1CBN"] =
+        @benchmarkable count(res -> res.id.name == "ALA", $struc)
+end

--- a/benchmark/PDB/Distance.jl
+++ b/benchmark/PDB/Distance.jl
@@ -1,0 +1,6 @@
+let
+    pdb_file = joinpath(@__DIR__, "..", "..", "test", "data", "1CBN.pdb")
+    struc = read_file(pdb_file, PDBFile, model = "1", chain = "A", group = "ATOM")
+
+    SUITE["PDB"]["distance"]["1CBN_20_30"] = @benchmarkable distance($struc[20], $struc[30])
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,11 +3,21 @@ using Random
 using MIToS.Utils
 using MIToS.MSA
 using MIToS.Information
+using MIToS.PDB
 
 const SUITE = BenchmarkGroup()
 
 include("Utils/GeneralUtils.jl")
 include("MSA/Residues.jl")
 include("MSA/Annotations.jl")
+include("MSA/Read.jl")
+include("MSA/Write.jl")
+include("MSA/Identity.jl")
+include("MSA/Clustering.jl")
 include("Information/CorrectedMutualInformation.jl")
 include("Information/Counters.jl")
+include("Information/Entropy.jl")
+include("Information/HighLevel.jl")
+include("Information/MIp.jl")
+include("PDB/Count.jl")
+include("PDB/Distance.jl")


### PR DESCRIPTION
## Summary
- integrate more MIToS benchmarks
- note benchmark instructions in AGENTS
- remove warmup call in PDB distance benchmark

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("Utils"); MIToSTests.retest("Utils")'`
- `julia --project -e 'import PkgBenchmark, MIToS; PkgBenchmark.benchmarkpkg(MIToS; retune=true)'`

------
https://chatgpt.com/codex/tasks/task_b_68533ab53acc832db665ccc607c4ee57