### PR TITLE
Add BioAlignments extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,10 +30,12 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [weakdeps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 ROCAnalysis = "f535d66d-59bb-5153-8d2b-ef0a426c6aff"
+BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
 
 [extensions]
 MIToSClusteringExt = "Clustering"
 MIToSROCAnalysisExt = "ROCAnalysis"
+MIToSBioAlignmentsExt = ["BioAlignments"]
 
 [compat]
 Aqua = "0.8"
@@ -66,6 +68,7 @@ StatsBase = "0.32, 0.33, 0.34"
 Test = "1"
 TranscodingStreams = "0.9, 0.10, 0.11"
 julia = "1.9"
+BioAlignments = "3"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -74,6 +77,7 @@ DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ROCAnalysis = "f535d66d-59bb-5153-8d2b-ef0a426c6aff"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
 
 [targets]
-test = ["Aqua", "DelimitedFiles", "Test", "ROCAnalysis", "Documenter", "Clustering"]
+test = ["Aqua", "DelimitedFiles", "Test", "ROCAnalysis", "Documenter", "Clustering", "BioAlignments"]

--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
 [extensions]
 MIToSClusteringExt = "Clustering"
 MIToSROCAnalysisExt = "ROCAnalysis"
-MIToSBioAlignmentsExt = ["BioAlignments"]
+MIToSBioAlignmentsExt = "BioAlignments"
 
 [compat]
 Aqua = "0.8"

--- a/ext/MIToSBioAlignmentsExt.jl
+++ b/ext/MIToSBioAlignmentsExt.jl
@@ -1,0 +1,44 @@
+module MIToSBioAlignmentsExt
+
+using MIToS.MSA
+using MIToS.MSA.ResidueSubstitutionMatrices: ResidueSubstitutionMatrix
+
+import BioAlignments
+
+function Base.convert(
+    ::Type{ResidueSubstitutionMatrix{T,A}},
+    submat::BioAlignments.SubstitutionMatrix{BioAlignments.BioSymbols.AminoAcid,S},
+) where {T<:Real,A<:ResidueAlphabet,S<:Real}
+    alphabet = A()
+    n = length(alphabet)
+    scores = fill(zero(T), n, n)
+    aa_alphabet = BioAlignments.BioSymbols.alphabet(submat)
+    for aa in aa_alphabet
+        c_a = Char(aa)
+        i = alphabet[Residue(c_a)]
+        for bb in aa_alphabet
+            c_b = Char(bb)
+            j = alphabet[Residue(c_b)]
+            scores[i, j] = convert(T, submat[c_a, c_b])
+        end
+    end
+    gap = alphabet[GAP]
+    scores[gap, :] .= -4
+    scores[:, gap] .= -4
+    scores[gap, gap] = 1
+
+    x = alphabet[XAA]
+    scores[x, :] .= -1
+    scores[:, x] .= -1
+    scores[x, x] = -1
+    scores[gap, x] = -4
+    scores[x, gap] = -4
+    return ResidueSubstitutionMatrix{T,A}(scores, alphabet)
+end
+
+Base.convert(
+    ::Type{ResidueSubstitutionMatrix},
+    submat::BioAlignments.SubstitutionMatrix{BioAlignments.BioSymbols.AminoAcid,S},
+) where {S<:Real} = convert(ResidueSubstitutionMatrix{S,GappedXAlphabet}, submat)
+
+end

--- a/test/MSA/BioAlignmentsExt.jl
+++ b/test/MSA/BioAlignmentsExt.jl
@@ -1,8 +1,6 @@
-using Pkg
-Pkg.add("BioAlignments")
 using MIToS.MSA.ResidueSubstitutionMatrices
 using MIToS.MSA
-using BioAlignments
+import BioAlignments
 
 @testset "BioAlignmentsExt" begin
     mito = MIToS.MSA.ResidueSubstitutionMatrices.BLOSUM62

--- a/test/MSA/BioAlignmentsExt.jl
+++ b/test/MSA/BioAlignmentsExt.jl
@@ -1,0 +1,13 @@
+using Pkg
+Pkg.add("BioAlignments")
+using MIToS.MSA.ResidueSubstitutionMatrices
+using MIToS.MSA
+using BioAlignments
+
+@testset "BioAlignmentsExt" begin
+    mito = MIToS.MSA.ResidueSubstitutionMatrices.BLOSUM62
+    bio = BioAlignments.BLOSUM62
+    conv = convert(ResidueSubstitutionMatrix, bio)
+    @test conv.scores == mito.scores
+    @test typeof(conv.alphabet) == typeof(mito.alphabet)
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -48,6 +48,7 @@ end
     include("MSA/Shuffle.jl")
     include("MSA/Identity.jl")
     include("MSA/ResidueSubstitutionMatrices.jl")
+    include("MSA/BioAlignmentsExt.jl")
     include("MSA/Hobohm.jl")
     include("MSA/MSAAnnotations.jl")
     include("MSA/GetIndex.jl")


### PR DESCRIPTION
## Summary
- add MIToSBioAlignmentsExt for converting substitution matrices
- test BioAlignments extension
- load new test file in main test script
- declare BioAlignments as a weak dep and configure compat
- drop BioSymbols from extension deps

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("BioAlignmentsExt")'`

------
https://chatgpt.com/codex/tasks/task_b_68532fc4033c832db849a3e43e316338