### PR TITLE
Allow predicate function for hobohmI

### DIFF
--- a/src/MSA/Hobohm.jl
+++ b/src/MSA/Hobohm.jl
@@ -3,11 +3,14 @@
 
 """
 Fill `cluster` and `clustersize` matrices. These matrices are assumed to be empty
-(only zeroes) and their length is assumed to be equal to the number of sequences in the
-alignment (`aln`). `threshold` is the minimum identity value between two sequences
-to be in the same cluster.
+(only zeroes) and their length is assumed to be equal to the number of sequences
+in the alignment (`aln`). `within_cluster` is a predicate function that takes two
+sequences and a `threshold` value and returns `true` if they should belong to the
+same cluster. `threshold` is passed as the last argument to
+`within_cluster`.
 """
 function _fill_hobohmI!(
+    within_cluster::Function,
     cluster::Vector{Int},
     clustersize::Vector{Int},
     aln::Vector{Vector{Residue}},
@@ -22,7 +25,7 @@ function _fill_hobohmI!(
             clustersize[cluster_id] += 1
             ref_seq = aln[i]
             for j = (i+1):nseq
-                if cluster[j] == 0 && percentidentity(ref_seq, aln[j], threshold)
+                if cluster[j] == 0 && within_cluster(ref_seq, aln[j], threshold)
                     cluster[j] = cluster_id
                     clustersize[cluster_id] += 1
                 end
@@ -51,18 +54,31 @@ function _get_sequence_weight(clustersize, cluster)
 end
 
 """
+`hobohmI(within_cluster, msa, threshold)`
+
 Sequence clustering using the Hobohm I method from Hobohm et al.
+`within_cluster` is a predicate function that receives two sequences and
+`threshold` and returns `true` when the sequences should be clustered together.
+The default behavior is obtained with `percentidentity`.
 
 # References
 
   - [Hobohm, Uwe, et al. "Selection of representative protein data sets."
     Protein Science 1.3 (1992): 409-417.](@cite 10.1002/pro.5560010313)
 """
-function hobohmI(msa::AbstractMatrix{Residue}, threshold)
+function hobohmI(within_cluster::Function, msa::AbstractMatrix{Residue}, threshold)
     aln = getresiduesequences(msa)
     nseq = length(aln)
     cluster = zeros(Int, nseq)
     clustersize = zeros(Int, nseq)
-    _fill_hobohmI!(cluster, clustersize, aln, threshold)
+    _fill_hobohmI!(within_cluster, cluster, clustersize, aln, threshold)
     Clusters(clustersize, cluster, _get_sequence_weight(clustersize, cluster))
 end
+
+"""
+`hobohmI(msa, threshold)`
+
+Convenience method for Hobohm I clustering using `percentidentity` as the
+predicate.
+"""
+hobohmI(msa::AbstractMatrix{Residue}, threshold) = hobohmI(percentidentity, msa, threshold)

--- a/test/MSA/Hobohm.jl
+++ b/test/MSA/Hobohm.jl
@@ -37,4 +37,11 @@ end
         cr = Clustering.dbscan(distance, 38.0, metric = nothing, min_neighbors = 2)
         @test convert(Clusters, cr) == clusters
     end
+
+    @testset "Do-block predicate" begin
+        clusters_do = hobohmI(fasta, 62) do s1, s2, thr
+            percentidentity(s1, s2, thr)
+        end
+        @test clusters_do == clusters
+    end
 end


### PR DESCRIPTION
## Summary
- allow passing a predicate function to `hobohmI`
- add do-block test for `hobohmI`

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("Hobohm I")'`

------
https://chatgpt.com/codex/tasks/task_b_685714a9123c832d9f465a2957d223e3