### PR TITLE
Add MMCIFDict conversion utilities

### DIFF
--- a/src/PDB/MMCIF.jl
+++ b/src/PDB/MMCIF.jl
@@ -2,9 +2,13 @@ struct MMCIFFile <: FileFormat end
 
 _clean_string(s::String) = replace(s, "." => "", "?" => "")
 
-function _parse_mmcif_to_pdbresidues(mmcif_dict::MMCIFDict, label::Bool)
+function _parse_mmcif_to_pdbresidues(mmcif_dict::BioStructures.MMCIFDict, label::Bool)
     # Choose the correct prefix based on the label argument
-    prefix = label ? "_atom_site.label" : "_atom_site.auth"
+    prefix = if label
+        "_atom_site.label"
+    else
+        "_atom_site.auth"
+    end
     chain_attr = string(prefix, "_asym_id")
     comp_id_attr = string(prefix, "_comp_id")
     atom_id_attr = string(prefix, "_atom_id")
@@ -99,7 +103,7 @@ function Utils.parse_file(
     label::Bool = true,
     occupancyfilter::Bool = false,
 )
-    mmcif_dict = MMCIFDict(io)
+    mmcif_dict = BioStructures.MMCIFDict(io)
 
     residues = select_residues(
         _parse_mmcif_to_pdbresidues(mmcif_dict, label),
@@ -131,24 +135,19 @@ function _inscode(res::PDBResidue)
     return m === nothing ? "?" : m.match
 end
 
-function _pdbresidues_to_mmcifdict(
-    residues::Vector{PDBResidue};
-    label::Bool = false,
-    molecular_structures::Bool = false,
-)
+function _pdbresidues_to_mmcifdict(residues::Vector{PDBResidue}; label::Bool = false)
     # Initialize MMCIFDict with the necessary fields
-    mmcif_dict = MMCIFDict()
+    mmcif_dict = BioStructures.MMCIFDict()
 
     # Initialize fields as empty arrays
-    if molecular_structures || !label
-        mmcif_dict["_atom_site.auth_asym_id"] = String[]
-        mmcif_dict["_atom_site.auth_comp_id"] = String[]
-        mmcif_dict["_atom_site.auth_atom_id"] = String[]
-    end
     if label
         mmcif_dict["_atom_site.label_asym_id"] = String[]
         mmcif_dict["_atom_site.label_comp_id"] = String[]
         mmcif_dict["_atom_site.label_atom_id"] = String[]
+    else
+        mmcif_dict["_atom_site.auth_asym_id"] = String[]
+        mmcif_dict["_atom_site.auth_comp_id"] = String[]
+        mmcif_dict["_atom_site.auth_atom_id"] = String[]
     end
     mmcif_dict["_atom_site.id"] = String[]
     mmcif_dict["_atom_site.auth_seq_id"] = String[]
@@ -169,15 +168,14 @@ function _pdbresidues_to_mmcifdict(
 
     for res in residues
         for atom in res.atoms
-            if molecular_structures || !label
-                push!(mmcif_dict["_atom_site.auth_asym_id"], res.id.chain)
-                push!(mmcif_dict["_atom_site.auth_comp_id"], res.id.name)
-                push!(mmcif_dict["_atom_site.auth_atom_id"], atom.atom)
-            end
             if label
                 push!(mmcif_dict["_atom_site.label_asym_id"], res.id.chain)
                 push!(mmcif_dict["_atom_site.label_comp_id"], res.id.name)
                 push!(mmcif_dict["_atom_site.label_atom_id"], atom.atom)
+            else
+                push!(mmcif_dict["_atom_site.auth_asym_id"], res.id.chain)
+                push!(mmcif_dict["_atom_site.auth_comp_id"], res.id.name)
+                push!(mmcif_dict["_atom_site.auth_atom_id"], atom.atom)
             end
             push!(mmcif_dict["_atom_site.id"], string(atom_id_counter))
             push!(mmcif_dict["_atom_site.auth_seq_id"], _resnumber(res.id.number))
@@ -215,3 +213,32 @@ function Utils.print_file(
     mmcif_dict = _pdbresidues_to_mmcifdict(residues, label = label)
     writemmcif(io, mmcif_dict)
 end
+
+"""
+    BioStructures.MMCIFDict(residues::Vector{PDBResidue}; label::Bool = false)
+
+Create a `BioStructures.MMCIFDict` from a vector of `PDBResidue`s. Set
+`label = true` to fill the CIF dictionary using the `label_` fields instead of
+the `auth_` fields.
+"""
+function BioStructures.MMCIFDict(residues::Vector{PDBResidue}; label::Bool = false)
+    _pdbresidues_to_mmcifdict(residues; label = label)
+end
+
+"""
+    Base.convert(::Type{Vector{PDBResidue}}, mmcif_dict::BioStructures.MMCIFDict)
+
+Convert a `MMCIFDict` into a vector of `PDBResidue`s using the `label_` fields
+present in the dictionary.
+"""
+function Base.convert(::Type{Vector{PDBResidue}}, mmcif_dict::BioStructures.MMCIFDict)
+    _parse_mmcif_to_pdbresidues(mmcif_dict, true)
+end
+
+"""
+    Base.convert(::Type{BioStructures.MMCIFDict}, residues::Vector{PDBResidue})
+
+Return a `MMCIFDict` representation of `residues` using the `auth_` fields.
+"""
+Base.convert(::Type{BioStructures.MMCIFDict}, residues::Vector{PDBResidue}) =
+    BioStructures.MMCIFDict(residues)

--- a/src/PDB/MMCIF.jl
+++ b/src/PDB/MMCIF.jl
@@ -232,7 +232,8 @@ Convert a `MMCIFDict` into a vector of `PDBResidue`s using the `label_` fields
 present in the dictionary.
 """
 function Base.convert(::Type{Vector{PDBResidue}}, mmcif_dict::BioStructures.MMCIFDict)
-    _parse_mmcif_to_pdbresidues(mmcif_dict, true)
+    label = haskey(mmcif_dict, "_atom_site.label_asym_id")
+    _parse_mmcif_to_pdbresidues(mmcif_dict, label)
 end
 
 """

--- a/test/PDB/BioStructures.jl
+++ b/test/PDB/BioStructures.jl
@@ -1,5 +1,3 @@
-import BioStructures
-
 @testset "MMCIFDict conversions" begin
     cif_file = joinpath(DATA, "2vqc.cif")
 

--- a/test/PDB/BioStructures.jl
+++ b/test/PDB/BioStructures.jl
@@ -1,0 +1,53 @@
+@testset "MMCIFDict conversions" begin
+    cif_file = joinpath(DATA, "2vqc.cif")
+
+    @testset "label = true" begin
+        residues = read_file(cif_file, MMCIFFile)
+        dict = BioStructures.MMCIFDict(residues; label = true)
+        @test convert(Vector{PDBResidue}, dict) == residues
+        ref = BioStructures.MMCIFDict(cif_file)
+        numeric_fields = Set([
+            "_atom_site.Cartn_x",
+            "_atom_site.Cartn_y",
+            "_atom_site.Cartn_z",
+            "_atom_site.occupancy",
+            "_atom_site.B_iso_or_equiv",
+        ])
+        for field in keys(dict)
+            @test haskey(ref, field)
+            if field in numeric_fields
+                @test all(
+                    parse(Float64, d) == parse(Float64, r) for
+                    (d, r) in zip(dict[field], ref[field])
+                )
+            else
+                @test ref[field] == dict[field]
+            end
+        end
+    end
+
+    @testset "label = false" begin
+        residues = read_file(cif_file, MMCIFFile, label = false)
+        dict = BioStructures.MMCIFDict(residues; label = false)
+        @test convert(Vector{PDBResidue}, dict) == residues
+        ref = BioStructures.MMCIFDict(cif_file)
+        numeric_fields = Set([
+            "_atom_site.Cartn_x",
+            "_atom_site.Cartn_y",
+            "_atom_site.Cartn_z",
+            "_atom_site.occupancy",
+            "_atom_site.B_iso_or_equiv",
+        ])
+        for field in keys(dict)
+            @test haskey(ref, field)
+            if field in numeric_fields
+                @test all(
+                    parse(Float64, d) == parse(Float64, r) for
+                    (d, r) in zip(dict[field], ref[field])
+                )
+            else
+                @test ref[field] == dict[field]
+            end
+        end
+    end
+end

--- a/test/PDB/BioStructures.jl
+++ b/test/PDB/BioStructures.jl
@@ -1,3 +1,5 @@
+import BioStructures
+
 @testset "MMCIFDict conversions" begin
     cif_file = joinpath(DATA, "2vqc.cif")
 

--- a/test/PDB/BioStructures.jl
+++ b/test/PDB/BioStructures.jl
@@ -4,6 +4,8 @@
     @testset "label = true" begin
         residues = read_file(cif_file, MMCIFFile)
         dict = BioStructures.MMCIFDict(residues; label = true)
+        @test convert(BioStructures.MMCIFDict, residues) ==
+              BioStructures.MMCIFDict(residues)
         @test convert(Vector{PDBResidue}, dict) == residues
         ref = BioStructures.MMCIFDict(cif_file)
         numeric_fields = Set([
@@ -30,6 +32,8 @@
         residues = read_file(cif_file, MMCIFFile, label = false)
         dict = BioStructures.MMCIFDict(residues; label = false)
         @test convert(Vector{PDBResidue}, dict) == residues
+        @test convert(BioStructures.MMCIFDict, residues) ==
+              BioStructures.MMCIFDict(residues)
         ref = BioStructures.MMCIFDict(cif_file)
         numeric_fields = Set([
             "_atom_site.Cartn_x",

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -7,6 +7,7 @@ using MIToS.Information
 using MIToS.PDB
 using MIToS.SIFTS
 using MIToS.Pfam
+import BioStructures
 using Aqua
 using LinearAlgebra
 using Random

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -75,6 +75,7 @@ end
 # PDB
 @testset verbose = true "PDB" begin
     include("PDB/PDB.jl")
+    include("PDB/BioStructures.jl")
     include("PDB/Contacts.jl")
     include("PDB/Kabsch.jl")
     include("PDB/Internals.jl")


### PR DESCRIPTION
## Summary
- add conversions between `Vector{PDBResidue}` and `BioStructures.MMCIFDict`
- test these conversions
- simplify conversion helper signature and remove unused function
- refine conversions using `if`/`else` and update tests to call `read_file`
- rename test file to `BioStructures.jl` and compare results against `BioStructures.MMCIFDict`

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'`

------
https://chatgpt.com/codex/tasks/task_b_685584d1d3b0832d89a4b0df2bc95b45