### PR TITLE
Add flexible hobohmI for general vectors

### DIFF
--- a/docs/src/MSA.md
+++ b/docs/src/MSA.md
@@ -693,6 +693,17 @@ println("This MSA has ", nsequences(msa), " sequences...")
 clusters = hobohmI(msa, 62)
 ```
 
+`hobohmI` can also receive any vector of items together with a custom
+`within_cluster` function, so it may be used to cluster unaligned sequences,
+protein structures or other data.  If you already extracted the aligned
+sequences as a vector of residue vectors, you can call it directly:
+
+```@example msa_clusters
+seqs = getresiduesequences(msa)
+clusters_vec = hobohmI(percentidentity, seqs, 62)
+@assert clusters == clusters_vec
+```
+
 ```@example msa_clusters
 println(
     "...but has only ",

--- a/src/MSA/Hobohm.jl
+++ b/src/MSA/Hobohm.jl
@@ -2,39 +2,39 @@
 # ========
 
 """
-Fill `cluster` and `clustersize` matrices. These matrices are assumed to be empty
-(only zeroes) and their length is assumed to be equal to the number of sequences
-in the alignment (`aln`). `within_cluster` is a predicate function that takes two
-sequences and a `threshold` value and returns `true` if they should belong to the
-same cluster. `threshold` is passed as the last argument to
-`within_cluster`.
+Fill `cluster` and `clustersize` vectors. They are assumed to be empty (only
+zeroes) and their length must be equal to the number of elements to cluster.
+`within_cluster` is a predicate that takes two items and a `threshold` and
+returns `true` if they should belong to the same cluster. `threshold` is passed
+as the last argument to `within_cluster`. The number of elements is stored in
+`n_items`.
 """
 function _fill_hobohmI!(
     within_cluster::Function,
     cluster::Vector{Int},
     clustersize::Vector{Int},
-    aln::Vector{Vector{Residue}},
+    items::AbstractVector,
     threshold,
 )
     cluster_id = 0
-    nseq = length(aln)
-    @inbounds for i = 1:(nseq-1)
+    n_items = length(items)
+    @inbounds for i = 1:(n_items-1)
         if cluster[i] == 0
             cluster_id += 1
             cluster[i] = cluster_id
             clustersize[cluster_id] += 1
-            ref_seq = aln[i]
-            for j = (i+1):nseq
-                if cluster[j] == 0 && within_cluster(ref_seq, aln[j], threshold)
+            ref_item = items[i]
+            for j = (i+1):n_items
+                if cluster[j] == 0 && within_cluster(ref_item, items[j], threshold)
                     cluster[j] = cluster_id
                     clustersize[cluster_id] += 1
                 end
             end
         end
     end
-    @inbounds if cluster[nseq] == 0
+    @inbounds if cluster[n_items] == 0
         cluster_id += 1
-        cluster[nseq] = cluster_id
+        cluster[n_items] = cluster_id
         clustersize[cluster_id] += 1
     end
     resize!(clustersize, cluster_id)
@@ -45,40 +45,50 @@ Calculates the weight of each sequence in a cluster. The weight is equal to one 
 by the number of sequences in the cluster.
 """
 function _get_sequence_weight(clustersize, cluster)
-    nseq = length(cluster)
-    sequence_weight = Array{Float64}(undef, nseq)
-    for i = 1:nseq
+    n_items = length(cluster)
+    sequence_weight = Array{Float64}(undef, n_items)
+    for i = 1:n_items
         @inbounds sequence_weight[i] = 1.0 / clustersize[cluster[i]]
     end
     Weights(sequence_weight, Float64(length(clustersize)))
 end
 
 """
-`hobohmI(within_cluster, msa, threshold)`
+`hobohmI(within_cluster, items, threshold)`
 
-Sequence clustering using the Hobohm I method from Hobohm et al.
-`within_cluster` is a predicate function that receives two sequences and
-`threshold` and returns `true` when the sequences should be clustered together.
-The default behavior is obtained with `percentidentity`.
+Cluster `items` using the Hobohm I algorithm from Hobohm et al. `within_cluster`
+is a predicate that receives two elements and `threshold` and returns `true` when
+they should be clustered together.
 
 # References
 
   - [Hobohm, Uwe, et al. "Selection of representative protein data sets."
     Protein Science 1.3 (1992): 409-417.](@cite 10.1002/pro.5560010313)
 """
+function hobohmI(within_cluster::Function, items::AbstractVector, threshold)
+    n = length(items)
+    cluster = zeros(Int, n)
+    clustersize = zeros(Int, n)
+    _fill_hobohmI!(within_cluster, cluster, clustersize, items, threshold)
+    Clusters(clustersize, cluster, _get_sequence_weight(clustersize, cluster))
+end
+
+"""
+`hobohmI(within_cluster, msa, threshold)`
+
+This method allows clustering the aligned sequences in `msa` using the
+`within_cluster` predicate. It converts the alignment into a vector of
+residue sequences and forwards the call to the general method.
+"""
 function hobohmI(within_cluster::Function, msa::AbstractMatrix{Residue}, threshold)
     aln = getresiduesequences(msa)
-    nseq = length(aln)
-    cluster = zeros(Int, nseq)
-    clustersize = zeros(Int, nseq)
-    _fill_hobohmI!(within_cluster, cluster, clustersize, aln, threshold)
-    Clusters(clustersize, cluster, _get_sequence_weight(clustersize, cluster))
+    hobohmI(within_cluster, aln, threshold)
 end
 
 """
 `hobohmI(msa, threshold)`
 
-Convenience method for Hobohm I clustering using `percentidentity` as the
-predicate.
+This method allows to cluster the sequences contained in `msa` using
+`percentidentity` as the clustering predicate.
 """
 hobohmI(msa::AbstractMatrix{Residue}, threshold) = hobohmI(percentidentity, msa, threshold)

--- a/test/MSA/Hobohm.jl
+++ b/test/MSA/Hobohm.jl
@@ -44,4 +44,10 @@ end
         end
         @test clusters_do == clusters
     end
+
+    @testset "Vector input" begin
+        seqs = getresiduesequences(fasta)
+        clusters_vec = hobohmI(percentidentity, seqs, 62)
+        @test clusters_vec == clusters
+    end
 end


### PR DESCRIPTION
## Summary
- generalize `hobohmI` to cluster any collection using `n_items` and `ref_item`
- note in docs that `hobohmI` accepts any vector of elements
- clarify docstrings for `hobohmI` methods

## Testing
- `julia --project -e 'using Pkg; Pkg.add("BioAlignments")'`
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("Information")'`


------
https://chatgpt.com/codex/tasks/task_b_685a4dc75994832dbf7a5f197bbcf7c5