### PR TITLE
Add tests for PDBResidue MolecularStructure

### DIFF
--- a/test/PDB/BioStructures.jl
+++ b/test/PDB/BioStructures.jl
@@ -55,3 +55,51 @@
         end
     end
 end
+
+@testset "MolecularStructure from residues" begin
+    pdb_file = joinpath(DATA, "1SSX.pdb")
+    residues = read_file(pdb_file, PDBFile)
+    str_from_vec = BioStructures.MolecularStructure(residues)
+    str_ref = BioStructures.read(pdb_file, BioStructures.PDBFormat)
+
+    @test BioStructures.countmodels(str_from_vec) == BioStructures.countmodels(str_ref)
+    @test BioStructures.countchains(str_from_vec) == BioStructures.countchains(str_ref)
+    @test BioStructures.countresidues(str_from_vec) == BioStructures.countresidues(str_ref)
+    @test BioStructures.countatoms(str_from_vec) == BioStructures.countatoms(str_ref)
+
+    info(r) = (
+        BioStructures.resname(r),
+        BioStructures.resnumber(r),
+        BioStructures.inscode(r),
+        BioStructures.ishetero(r),
+        length(r),
+    )
+    @test [info(r) for r in BioStructures.collectresidues(str_from_vec)] == [info(r) for r in BioStructures.collectresidues(str_ref)]
+
+    atominfo(res) = [
+        (
+            BioStructures.atomname(a),
+            BioStructures.altlocid(a) == '\0' ? ' ' : BioStructures.altlocid(a),
+        ) for a in res
+    ]
+    @test [atominfo(r) for r in BioStructures.collectresidues(str_from_vec)] == [atominfo(r) for r in BioStructures.collectresidues(str_ref)]
+
+    first_two = [
+        (BioStructures.resnumber(r), BioStructures.inscode(r)) for
+        r in BioStructures.collectresidues(str_from_vec)[1:2]
+    ]
+    @test first_two == [(15, 'A'), (15, 'B')]
+
+    function altlocs_ca(str)
+        for r in BioStructures.collectresidues(str)
+            BioStructures.resnumber(r) == 90 || continue
+            for at in r
+                if BioStructures.atomname(at) == "CA"
+                    return sort(BioStructures.altlocids(at))
+                end
+            end
+        end
+        Char[]
+    end
+    @test altlocs_ca(str_from_vec) == altlocs_ca(str_ref) == ['A', 'B']
+end


### PR DESCRIPTION
## Summary
- expand BioStructures tests to cover `MolecularStructure(residues::Vector{PDBResidue})`
- verify structural counts, residue data, and altloc handling against BioStructures parsing
- add explicit checks for insertion codes and alternate locations

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'`

------
https://chatgpt.com/codex/tasks/task_b_685a67121054832d901f15ffa5ca2913