### PR TITLE
Add Externals.jl tests without GaussDCA dependency

### DIFF
--- a/test/Information/Externals.jl
+++ b/test/Information/Externals.jl
@@ -3,11 +3,12 @@
     script = base * ".jl"
     msa_file = base * ".fasta"
     jdl_file = base * ".jls"
-    _create_script(script, msa_file, jdl_file; min_separation = 2, mode = :fast)
+    MIToS.Information._create_script(script, msa_file, jdl_file; min_separation = 2, mode = :fast)
     content = read(script, String)
     @test occursin("min_separation=2", content)
     @test occursin("mode=:fast", content)
-    @test_throws ArgumentError _create_script(script, msa_file, jdl_file; bad = "x")
+    @test occursin("GaussDCA.gDCA(\"$msa_file\"", content)
+    @test_throws ArgumentError MIToS.Information._create_script(script, msa_file, jdl_file; bad = "x")
     rm(script)
 end
 


### PR DESCRIPTION
## Summary
- test `_create_script` function
- keep optional test that installs `GaussDCA`
- remove stub `GaussDCA` package

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("Information"); MIToSTests.retest("Information")'`

------
https://chatgpt.com/codex/tasks/task_b_685a67f9b46c832d804435a973c8b987