### PR TITLE
Update PDB docs and add MMCIFFile docstring

### DIFF
--- a/src/PDB/MMCIF.jl
+++ b/src/PDB/MMCIF.jl
@@ -1,3 +1,8 @@
+"""
+`MMCIFFile <: FileFormat`
+
+macromolecular Crystallographic Information File (mmCIF) format.
+"""
 struct MMCIFFile <: FileFormat end
 
 _clean_string(s::String) = replace(s, "." => "", "?" => "")

--- a/src/PDB/PDB.jl
+++ b/src/PDB/PDB.jl
@@ -5,7 +5,7 @@ needed for measure the predictive performance at protein contact prediction of m
 
 **Features**
 
-  - Read and parse PDF and PDBML files
+  - Read and parse mmCIF, PDB and PDBML files.
   - Calculate distance and contacts between atoms or residues
   - Determine interaction between residues
 


### PR DESCRIPTION
## Summary
- fix feature bullet in `PDB` docs
- document `MMCIFFile` type

## Testing
- `julia --project /tmp/pdb_tests.jl` *(fails: `downloadpdb` not defined)*

------
https://chatgpt.com/codex/tasks/task_b_685ba27d23cc832db559621cace8814f