### PR TITLE
Add tests for rename_sequences! pair and dict

### DIFF
--- a/test/MSA/MultipleSequenceAlignment.jl
+++ b/test/MSA/MultipleSequenceAlignment.jl
@@ -257,15 +257,42 @@
                     setannotsequence!(copied_object, "1", "Name", "One")
                     setannotresidue!(copied_object, "1", "SS", "HHHHHHH")
                 end
-                # Testing only rename_sequences with Pairs
-                # as rename_sequences calls rename_sequences! and 
-                # Pairs are transformed to Dict and then to Vectors using _newnames
                 new_object = rename_sequences(copied_object, "1" => "I", "2" => "II")
                 @test sequencenames(copied_object) == ["1", "2", "3"]
                 @test sequencenames(new_object) == ["I", "II", "3"]
                 if isa(new_object, AnnotatedMultipleSequenceAlignment)
                     @test getannotsequence(new_object, "I", "Name") == "One"
                     @test getannotresidue(new_object, "I", "SS") == "HHHHHHH"
+                end
+            end
+
+            # rename_sequences! with Dict
+            for object in (NamedArray(M), msa, annotated_msa)
+                copied_object = deepcopy(object)
+                if isa(copied_object, AnnotatedMultipleSequenceAlignment)
+                    setannotsequence!(copied_object, "1", "Name", "One")
+                    setannotresidue!(copied_object, "1", "SS", "HHHHHHH")
+                end
+                rename_sequences!(copied_object, Dict("1" => "I", "2" => "II"))
+                @test sequencenames(copied_object) == ["I", "II", "3"]
+                if isa(copied_object, AnnotatedMultipleSequenceAlignment)
+                    @test getannotsequence(copied_object, "I", "Name") == "One"
+                    @test getannotresidue(copied_object, "I", "SS") == "HHHHHHH"
+                end
+            end
+
+            # rename_sequences! with Pairs
+            for object in (NamedArray(M), msa, annotated_msa)
+                copied_object = deepcopy(object)
+                if isa(copied_object, AnnotatedMultipleSequenceAlignment)
+                    setannotsequence!(copied_object, "1", "Name", "One")
+                    setannotresidue!(copied_object, "1", "SS", "HHHHHHH")
+                end
+                rename_sequences!(copied_object, "1" => "I", "2" => "II")
+                @test sequencenames(copied_object) == ["I", "II", "3"]
+                if isa(copied_object, AnnotatedMultipleSequenceAlignment)
+                    @test getannotsequence(copied_object, "I", "Name") == "One"
+                    @test getannotresidue(copied_object, "I", "SS") == "HHHHHHH"
                 end
             end
         end


### PR DESCRIPTION
## Summary
- increase coverage for `rename_sequences!` dispatches on `Dict` and `Pair`
- clean up outdated comments

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA")'` *(fails: 0 tests run)*
- `julia --project -e 'using Pkg; Pkg.test(coverage=true)'` *(failed to complete)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_685bcc6662ac832d8c2744960b235bbb