### PR TITLE
Remove unused strings_to_msa helper

### DIFF
--- a/src/MSA/GeneralParserMethods.jl
+++ b/src/MSA/GeneralParserMethods.jl
@@ -364,38 +364,6 @@ function _generate_annotated_msa(
     msa
 end
 
-
-# Matrix{Residue} and NamedArray{Residue,2}
-# -----------------------------------------
-#
-# This checks that all the sequences have the same length
-#
-
-function _strings_to_msa(
-    ::Type{NamedArray{Residue,2}},
-    seqs::Vector{String},
-    deletefullgaps::Bool,
-)
-    msa = NamedArray(convert(Matrix{Residue}, seqs))
-    setdimnames!(msa, ("Seq", "Col"))
-    if deletefullgaps
-        return (deletefullgapcolumns(msa))
-    end
-    msa
-end
-
-function _strings_to_msa(
-    ::Type{Matrix{Residue}},
-    seqs::Vector{String},
-    deletefullgaps::Bool,
-)
-    msa = convert(Matrix{Residue}, seqs)
-    if deletefullgaps
-        return (deletefullgapcolumns(msa))
-    end
-    msa
-end
-
 # Unsafe: It doesn't check sequence lengths
 # Use it after _pre_read... calling _check_seq_...
 function _strings_to_matrix_residue_unsafe(seqs::Vector{String}, deletefullgaps::Bool)
@@ -405,7 +373,6 @@ function _strings_to_matrix_residue_unsafe(seqs::Vector{String}, deletefullgaps:
     end
     msa
 end
-
 
 # Delete Full of Gap Columns
 # ==========================


### PR DESCRIPTION
## Summary
- delete obsolete `_strings_to_msa` methods

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("GeneralParserMethods"); MIToSTests.retest("GeneralParserMethods")'`

------
https://chatgpt.com/codex/tasks/task_b_685d31e05238832db8d0e31dbbc2363c