### PR TITLE
Add tests for getCA

### DIFF
--- a/test/PDB/Kabsch.jl
+++ b/test/PDB/Kabsch.jl
@@ -279,6 +279,28 @@
         end
     end
 
+    @testset "getCA" begin
+        @testset "empty residue" begin
+            id = PDBResidueIdentifier("1", "1", "GLY", "ATOM", "1", "A")
+            res = PDBResidue(id, PDBAtom[])
+            @test (@test_logs (:warn, r"There are no atoms in residue") match_mode =
+                :any begin
+                getCA(res)
+            end) === missing
+        end
+
+        @testset "best occupancy" begin
+            id = PDBResidueIdentifier("1", "1", "ALA", "ATOM", "1", "A")
+            atoms = [
+                PDBAtom(Coordinates(0.0, 0.0, 0.0), "CA", "C", 0.5, "0", "", ""),
+                PDBAtom(Coordinates(1.0, 0.0, 0.0), "CA", "C", 1.0, "0", "", ""),
+                PDBAtom(Coordinates(0.0, 1.0, 0.0), "CB", "C", 0.8, "0", "", ""),
+            ]
+            res = PDBResidue(id, atoms)
+            @test getCA(res) === atoms[2]
+        end
+    end
+
     @testset "PDBResidue without alpha-carbon" begin
         small_2WEL = read_file(joinpath(DATA, "2WEL_D_region.pdb"), PDBFile)
         small_6BAB = read_file(joinpath(DATA, "6BAB_D_region.pdb"), PDBFile)


### PR DESCRIPTION
## Summary
- ensure `getCA` warns on empty residues and returns `missing`
- verify selection of alpha carbon with highest occupancy

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("Kabsch algorithm")'`

------
https://chatgpt.com/codex/tasks/task_b_685e69ea0af4832da76725b785b59ea9