### PR TITLE
Add sequence indexing tests

### DIFF
--- a/src/MSA/GetIndex.jl
+++ b/src/MSA/GetIndex.jl
@@ -175,5 +175,5 @@ end
 # TODO: AnnotatedSequence
 
 function Base.getindex(seq::AlignedSequence, cols::Union{AbstractArray,Colon})
-    AlignedSequence(seq.matrix[cols])
+    AlignedSequence(seq.matrix[:, cols])
 end

--- a/test/MSA/GetIndex.jl
+++ b/test/MSA/GetIndex.jl
@@ -158,4 +158,41 @@
             end
         end
     end
+
+    @testset "Sequences" begin
+        msa = read_file(simple, FASTA, generatemapping = true)
+        annseq = getsequence(msa, 1)
+
+        @testset "AnnotatedAlignedSequence" begin
+            rev = annseq[[2, 1]]
+            @test isa(rev, AnnotatedAlignedSequence)
+            @test getresidues(rev) == Residue['R' 'A']
+            annot_vals = Set(values(getannotfile(rev)))
+            @test any(
+                occursin("filtercolumns! : 2 columns have been selected.", v) for
+                v in annot_vals
+            )
+            @test any(
+                occursin("filtercolumns! : column order has changed!", v) for
+                v in annot_vals
+            )
+
+            single = annseq[[2]]
+            @test isa(single, AnnotatedAlignedSequence)
+            @test getresidues(single) == reshape(res"R", 1, 1)
+            annot_vals = Set(values(getannotfile(single)))
+            @test any(occursin("filtercolumns! : 1 column has been", v) for v in annot_vals)
+        end
+
+        @testset "AlignedSequence" begin
+            seq = AlignedSequence(annseq)
+            rev = seq[[2, 1]]
+            @test isa(rev, AlignedSequence)
+            @test getresidues(rev) == Residue['R' 'A']
+
+            copy_all = seq[:]
+            @test isa(copy_all, AlignedSequence)
+            @test getresidues(copy_all) == getresidues(seq)
+        end
+    end
 end


### PR DESCRIPTION
## Summary
- test AnnotatedAlignedSequence and AlignedSequence column selection
- fix getindex for AlignedSequence to keep matrix shape

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("getindex"); MIToSTests.retest("getindex")'`

------
https://chatgpt.com/codex/tasks/task_b_685e6c3ade68832d948c54ee9ae4645e