### PR TITLE
Add join_msas IO test

### DIFF
--- a/test/MSA/Concatenation.jl
+++ b/test/MSA/Concatenation.jl
@@ -173,6 +173,39 @@
             @test gethcatmapping(concat_a) == [1, 1, 2, 2, 3, 3]
         end
     end
+
+    @testset "join_msas IO" begin
+        # Ensure joined MSAs can be written and read losslessly
+        # and still be joined with further MSAs
+        # Read input MSAs
+        msa_a = read_file(joinpath(DATA, "simple.fasta"), FASTA, generatemapping = true)
+        msa_b =
+            read_file(joinpath(DATA, "Gaoetal2011.fasta"), FASTA, generatemapping = true)
+        msa_c = copy(msa_a)
+
+        pairing = [1, 2] .=> [1, 2]
+        joined_ab = join_msas(msa_a, msa_b, pairing, axis = 1)
+
+        mktemp() do tmp_file, io
+            # Write the joined MSA keeping `io` open
+            print_file(io, joined_ab, Stockholm)
+            flush(io)
+
+            # Read the joined MSA from the same IO
+            seekstart(io)
+            joined_read = parse_file(io, Stockholm)
+
+            @test joined_read == joined_ab
+            @test annotations(joined_read) == annotations(joined_ab)
+
+            # Join a third MSA and compare both results
+            joined_original = join_msas(joined_ab, msa_c, pairing, axis = 1)
+            joined_from_file = join_msas(joined_read, msa_c, pairing, axis = 1)
+
+            @test joined_from_file == joined_original
+            @test annotations(joined_from_file) == annotations(joined_original)
+        end
+    end
 end
 
 @testset "vcat" begin


### PR DESCRIPTION
## Summary
- add a new test for join_msas read/write behaviour
- use `mktemp` for temporary file handling and reuse the open `io`
- parse the file from the same `io` to verify annotations survive round-trip

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("hcat"); MIToSTests.retest("hcat")'`


------
https://chatgpt.com/codex/tasks/task_b_685e6bf098dc832dbbcfcfc0eb6bc51c