### PR TITLE
Add test for PDBResidue bestoccupancy

### DIFF
--- a/test/PDB/PDB.jl
+++ b/test/PDB/PDB.jl
@@ -129,10 +129,17 @@
             @test bestoccupancy(atoms_141)[1].occupancy == 0.75
             @test bestoccupancy(reverse(atoms_141))[1].occupancy == 0.75
             @test bestoccupancy(PDBAtom[atoms_141[2]])[1].occupancy == 0.25
-
             @test length(resid_141[1]) == 48
+
             @test selectbestoccupancy(resid_141[1], collect(1:48)) == 1
             @test selectbestoccupancy(resid_141[1], [1, 2]) == 1
+
+            res_best = bestoccupancy(resid_141[1])
+            @test length(res_best) == 24
+            @test res_best.id == resid_141[1].id
+            hh22 = [a for a in res_best.atoms if a.atom == "HH22"]
+            @test length(hh22) == 1
+            @test hh22[1].occupancy == 0.75
 
             @test_throws ArgumentError selectbestoccupancy(resid_141[1], Int[])
             @test_throws ArgumentError selectbestoccupancy(resid_141[1], collect(1:100))


### PR DESCRIPTION
## Summary
- test `bestoccupancy(::PDBResidue)` using residue 141 from 1SSX
- avoid redundant check on residue length

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'`


------
https://chatgpt.com/codex/tasks/task_b_685e9db21bec832dacb2791b5d00751a