### PR TITLE
Add join_msas error test

### DIFF
--- a/test/MSA/Concatenation.jl
+++ b/test/MSA/Concatenation.jl
@@ -1530,6 +1530,8 @@ end
                 [1, 2] .=> [3, 4],
                 kind = :iner,
             )
+            # kind is incorrect using two position lists
+            @test_throws ArgumentError join_msas(msa62, msa62, [1, 2], [3, 4], kind = :iner)
             # pairing is empty
             @test_throws ArgumentError join_msas(msa62, msa62, [])
             # each element of the pairing is not a pair


### PR DESCRIPTION
## Summary
- test that `join_msas` throws an `ArgumentError` when `kind` is wrong for the two-list form

## Testing
- `MIToSTests.retest("MSA"); MIToSTests.retest("ArgumentErrors")`

------
https://chatgpt.com/codex/tasks/task_b_685ea08ceaa0832dba3226c7d3eceb56