### PR TITLE
Add test for SIFTS parse_file error

### DIFF
--- a/test/SIFTS/SIFTS.jl
+++ b/test/SIFTS/SIFTS.jl
@@ -349,3 +349,9 @@ end
     res_scop2b = mapping_scop2b[findfirst(res -> !ismissing(res.SCOP2B), mapping_scop2b)]
     @test get(res_scop2b, dbSCOP2B) == res_scop2b.SCOP2B
 end
+
+@testset "parse_file error" begin
+    io = IOBuffer()
+    @test_throws ArgumentError Utils.parse_file(io, SIFTSXML)
+    @test_throws ArgumentError Utils.parse_file("dummy", SIFTSXML)
+end


### PR DESCRIPTION
## Summary
- check that `parse_file` for `SIFTSXML` throws an error if called with an `IO` or a `String`

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("SIFTS"); MIToSTests.retest("parse_file error"); MIToSTests.retest("parse_file error")'`

------
https://chatgpt.com/codex/tasks/task_b_685ea0edfdcc832da5340cb906e2896b