### PR TITLE
Add missing PIR warnings test

### DIFF
--- a/test/MSA/Sequences.jl
+++ b/test/MSA/Sequences.jl
@@ -203,5 +203,16 @@
             out_raw = parse_file(io, RawSequences)
             @test in_raw == out_raw
         end
+
+        @testset "Missing annotations" begin
+            seq = AnnotatedSequence("SeqID", "ACDE", Annotations())
+            io = IOBuffer()
+            @test_logs (:warn, r"There is not sequence Type annotation for SeqID") (
+                :warn,
+                r"There is not sequence Title annotation for SeqID",
+            ) match_mode = :any begin
+                print_file(io, [seq], PIRSequences)
+            end
+        end
     end
 end


### PR DESCRIPTION
## Summary
- add test for warnings emitted when printing sequences in PIR format with missing Type and Title annotations

## Testing
- `julia --project -e 'using Test, MIToS, MIToS.Utils, MIToS.MSA; seq=AnnotatedSequence("SeqID","ACDE", Annotations()); io=IOBuffer(); @test_logs (:warn, r"There is not sequence Type annotation for SeqID") (:warn, r"There is not sequence Title annotation for SeqID") match_mode=:any begin print_file(io,[seq], PIRSequences) end'`
- `julia --project -e 'using Pkg; Pkg.test(coverage=true)'` *(fails: Some tests did not pass)*

------
https://chatgpt.com/codex/tasks/task_b_685ea1517324832dbc5cb1c2e2c7283c