### PR TITLE
Optimize TRP plane computation

### DIFF
--- a/src/PDB/AtomsData.jl
+++ b/src/PDB/AtomsData.jl
@@ -324,6 +324,10 @@ const _aromatic = Set{Tuple{String,String}}([
     ("TYR", "CZ"),
 ])
 
+const _TRP_PLANE1_ATOMS = Set{String}(["CE2", "CD2", "CZ2", "CZ3", "CH2", "CE3"])
+
+const _TRP_PLANE2_ATOMS = Set{String}(["CG", "CD1", "NE1", "CE2", "CD2"])
+
 const _cationic = Set{Tuple{String,String}}([
     ("ARG", "CZ"),
     ("ARG", "NE"),

--- a/src/PDB/PDBResidues.jl
+++ b/src/PDB/PDBResidues.jl
@@ -949,30 +949,14 @@ end
 
 function _get_plane(residue::PDBResidue)
     name = residue.id.name
-    planes = Vector{PDBAtom}[]
     if name != "TRP"
-        plane = PDBAtom[]
-        for atom in residue.atoms
-            if (name, atom.atom) in PDB._aromatic
-                push!(plane, atom)
-            end
-        end
-        push!(planes, plane)
+        plane = [atom for atom in residue.atoms if (name, atom.atom) in PDB._aromatic]
+        return Vector{Vector{PDBAtom}}([plane])
     else
-        plane1 = PDBAtom[]
-        plane2 = PDBAtom[]
-        for atom in residue.atoms
-            if atom.atom in Set{String}(["CE2", "CD2", "CZ2", "CZ3", "CH2", "CE3"])
-                push!(plane1, atom)
-            end
-            if atom.atom in Set{String}(["CG", "CD1", "NE1", "CE2", "CD2"])
-                push!(plane2, atom)
-            end
-        end
-        push!(planes, plane1)
-        push!(planes, plane2)
+        plane1 = [atom for atom in residue.atoms if atom.atom in PDB._TRP_PLANE1_ATOMS]
+        plane2 = [atom for atom in residue.atoms if atom.atom in PDB._TRP_PLANE2_ATOMS]
+        return Vector{Vector{PDBAtom}}([plane1, plane2])
     end
-    planes
 end
 
 function _centre(planes::Vector{Vector{PDBAtom}})


### PR DESCRIPTION
## Summary
- add constant sets `_TRP_PLANE1_ATOMS` and `_TRP_PLANE2_ATOMS`
- refine `_get_plane` to use list comprehensions with these sets

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("Piccolo"); MIToSTests.retest("Piccolo")'`

------
https://chatgpt.com/codex/tasks/task_b_685e9c280bd0832da2bc8846e6999a6b