### PR TITLE
Add MMCIF parse_file filter tests

### DIFF
--- a/test/PDB/MMCIFParser.jl
+++ b/test/PDB/MMCIFParser.jl
@@ -1,0 +1,72 @@
+@testset "MMCIF parse_file filters" begin
+
+    occ_res = PDBResidue(
+        PDBResidueIdentifier("1", "1", "ALA", "ATOM", "1", "A"),
+        [
+            PDBAtom(
+                coordinates = Coordinates(0.0, 0.0, 0.0),
+                atom = "CA",
+                element = "C",
+                occupancy = 0.4,
+                B = "0",
+                alt_id = "A",
+                charge = "",
+            ),
+            PDBAtom(
+                coordinates = Coordinates(1.0, 0.0, 0.0),
+                atom = "CA",
+                element = "C",
+                occupancy = 0.6,
+                B = "0",
+                alt_id = "B",
+                charge = "",
+            ),
+        ],
+    )
+
+    heavy_res = PDBResidue(
+        PDBResidueIdentifier("2", "2", "GLY", "ATOM", "1", "A"),
+        [
+            PDBAtom(
+                coordinates = Coordinates(0.0, 0.0, 0.0),
+                atom = "CA",
+                element = "C",
+                occupancy = 1.0,
+                B = "0",
+                alt_id = "",
+                charge = "",
+            ),
+            PDBAtom(
+                coordinates = Coordinates(1.0, 0.0, 0.0),
+                atom = "H1",
+                element = "H",
+                occupancy = 1.0,
+                B = "0",
+                alt_id = "",
+                charge = "",
+            ),
+        ],
+    )
+
+    residues = [occ_res, heavy_res]
+    io = IOBuffer()
+    Utils.print_file(io, residues, MMCIFFile; label = true)
+    cif_str = String(take!(io))
+
+    # Without filters
+    parsed = parse_file(IOBuffer(cif_str), MMCIFFile)
+    @test length(parsed[1].atoms) == 2
+    @test length(parsed[2].atoms) == 2
+
+    # Occupancy filter
+    parsed_occ = parse_file(IOBuffer(cif_str), MMCIFFile; occupancyfilter = true)
+    @test length(parsed_occ[1].atoms) == 1
+    @test parsed_occ[1].atoms[1].occupancy == 0.6
+    @test length(parsed_occ[2].atoms) == 2
+
+    # Only heavy atoms
+    parsed_heavy = parse_file(IOBuffer(cif_str), MMCIFFile; onlyheavy = true)
+    @test length(parsed_heavy[1].atoms) == 2
+    @test length(parsed_heavy[2].atoms) == 1
+    @test parsed_heavy[2].atoms[1].element == "C"
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -86,6 +86,7 @@ end
     include("PDB/ShowConstructors.jl")
     include("PDB/Copy.jl")
     include("PDB/PDBResidues.jl")
+    include("PDB/MMCIFParser.jl")
     include("PDB/Plots.jl")
 end
 


### PR DESCRIPTION
## Summary
- verify `parse_file` filters in MMCIF parser
- hook new test file into the PDB test suite
- drop unnecessary `using MIToS.PDB`

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'`


------
https://chatgpt.com/codex/tasks/task_b_685ea1e50420832d830bdcf86bdefc50