### PR TITLE
Increase test coverage for mapping warnings

### DIFF
--- a/test/MSA/GeneralParserMethods.jl
+++ b/test/MSA/GeneralParserMethods.jl
@@ -146,4 +146,18 @@
         @test getannotsequence(annot, "x(1)(1)", "OriginalSeqName", "") == "x(1)"
         @test getannotsequence(annot, "x(1)(2)", "OriginalSeqName", "") == "x(1)"
     end
+
+    @testset "Mapping warnings" begin
+        fasta = joinpath(DATA, "simple.fasta")
+        msa = read_file(fasta, FASTA, generatemapping = true)
+        mktemp() do tmp, _
+            write_file(tmp, msa, Stockholm)
+            @test_logs (:warn, r"sequence mappings annotations") (
+                :warn,
+                r"column annotations",
+            ) match_mode = :all begin
+                read_file(tmp, Stockholm, generatemapping = true)
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Summary
- add test that checks for mapping warnings
- use `mktemp` to manage temporary files

## Testing
- `julia --project -e 'using Test, MIToS, MIToS.Utils, MIToS.MSA, OrderedCollections; const DATA=joinpath("test","data"); include("test/MSA/GeneralParserMethods.jl")'`

------
https://chatgpt.com/codex/tasks/task_b_685e9ed7f7ec832db042a1130e6128ce