### PR TITLE
Optimize array allocations in SIFTS and Kabsch helpers

### DIFF
--- a/src/PDB/Kabsch.jl
+++ b/src/PDB/Kabsch.jl
@@ -282,17 +282,12 @@ function _get_matched_Cαs(
     B::AbstractVector{PDBResidue},
     matches,
 )
-    if Base.IteratorSize(typeof(matches)) == Base.SizeUnknown()
-        Asel, Bsel = PDBResidue[], PDBResidue[]
-        for (i, j) in matches
-            push!(Asel, A[i])
-            push!(Bsel, B[j])
-        end
-        return _get_matched_Cαs(Asel, Bsel, nothing)
-    end
-    Asel = Vector{PDBResidue}(undef, length(matches))
+    pairs_iter =
+        Base.IteratorSize(typeof(matches)) == Base.SizeUnknown() ? collect(matches) :
+        matches
+    Asel = Vector{PDBResidue}(undef, length(pairs_iter))
     Bsel = similar(Asel)
-    for (k, (i, j)) in enumerate(matches)
+    for (k, (i, j)) in enumerate(pairs_iter)
         Asel[k] = A[i]
         Bsel[k] = B[j]
     end

--- a/src/SIFTS/ResidueMapping.jl
+++ b/src/SIFTS/ResidueMapping.jl
@@ -293,14 +293,19 @@ function SIFTSResidue(
     UniProt = missing
     Pfam = missing
     NCBI = missing
+    crossrefs = LightXML.get_elements_by_tagname(residue, "crossRefDb")
+    nrefs = length(crossrefs)
     InterPro = dbInterPro[]
+    sizehint!(InterPro, nrefs)
     PDB = missing
     SCOP = missing
     SCOP2 = dbSCOP2[]
+    sizehint!(SCOP2, nrefs)
     SCOP2B = missing
     CATH = missing
     Ensembl = dbEnsembl[]
-    for crossref in LightXML.get_elements_by_tagname(residue, "crossRefDb")
+    sizehint!(Ensembl, nrefs)
+    for crossref in crossrefs
         db = LightXML.attribute(crossref, "dbSource")
         if db == "UniProt"
             UniProt = dbUniProt(crossref)
@@ -434,7 +439,14 @@ function Utils.parse_file(
     chain::Union{Type{All},String} = All,
     missings::Bool = true,
 )
-    vector = SIFTSResidue[]
+    n_residues = 0
+    for entity in _get_entities(document)
+        for segment in _get_segments(entity)
+            n_residues += length(_get_residues(segment))
+        end
+    end
+    vector = Vector{SIFTSResidue}(undef, n_residues)
+    i = 0
     for entity in _get_entities(document)
         for segment in _get_segments(entity)
             residues = _get_residues(segment)
@@ -444,12 +456,14 @@ function Utils.parse_file(
                     sifts_res = SIFTSResidue(residue, missing_residue, sscode, ssname)
                     if _is_All(chain) ||
                        (!ismissing(sifts_res.PDB) && sifts_res.PDB.chain == chain)
-                        push!(vector, sifts_res)
+                        i += 1
+                        vector[i] = sifts_res
                     end
                 end
             end
         end
     end
+    resize!(vector, i)
     vector
 end
 


### PR DESCRIPTION
## Summary
- preallocate internal arrays when parsing SIFTS XML files
- avoid repeated `push!` when selecting matched residues in Kabsch alignment

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB", stats=true)'`
- `julia --project -e 'import PkgBenchmark, MIToS; PkgBenchmark.benchmarkpkg(MIToS; retune=false)'`

------
https://chatgpt.com/codex/tasks/task_b_686395411aec832d82178413b4d49d34