### PR TITLE
Implement AnnotatedSequence slicing

### DIFF
--- a/src/MSA/GetIndex.jl
+++ b/src/MSA/GetIndex.jl
@@ -172,7 +172,17 @@ function Base.getindex(seq::AnnotatedAlignedSequence, cols::AbstractArray)
     seq_copy
 end
 
-# TODO: AnnotatedSequence
+Base.getindex(seq::AnnotatedAlignedSequence, cols::Colon) = copy(seq)
+
+function Base.getindex(seq::AnnotatedSequence, cols::AbstractArray)
+    seq_copy = copy(seq)
+    col_selector = _column_indices(seq, cols)
+    filtercolumns!(seq_copy, col_selector)
+    _annotate_col_modification!(seq_copy, col_selector)
+    seq_copy
+end
+
+Base.getindex(seq::AnnotatedSequence, cols::Colon) = copy(seq)
 
 function Base.getindex(seq::AlignedSequence, cols::Union{AbstractArray,Colon})
     AlignedSequence(seq.matrix[:, cols])

--- a/test/MSA/GetIndex.jl
+++ b/test/MSA/GetIndex.jl
@@ -182,6 +182,10 @@
             @test getresidues(single) == reshape(res"R", 1, 1)
             annot_vals = Set(values(getannotfile(single)))
             @test any(occursin("filtercolumns! : 1 column has been", v) for v in annot_vals)
+
+            copy_all = annseq[:]
+            @test isa(copy_all, AnnotatedAlignedSequence)
+            @test getresidues(copy_all) == getresidues(annseq)
         end
 
         @testset "AlignedSequence" begin
@@ -192,6 +196,32 @@
 
             copy_all = seq[:]
             @test isa(copy_all, AlignedSequence)
+            @test getresidues(copy_all) == getresidues(seq)
+        end
+
+        @testset "AnnotatedSequence" begin
+            seq = AnnotatedSequence(annseq)
+            rev = seq[[2, 1]]
+            @test isa(rev, AnnotatedSequence)
+            @test getresidues(rev) == Residue['R' 'A']
+            annot_vals = Set(values(getannotfile(rev)))
+            @test any(
+                occursin("filtercolumns! : 2 columns have been selected.", v) for
+                v in annot_vals
+            )
+            @test any(
+                occursin("filtercolumns! : column order has changed!", v) for
+                v in annot_vals
+            )
+
+            single = seq[[2]]
+            @test isa(single, AnnotatedSequence)
+            @test getresidues(single) == reshape(res"R", 1, 1)
+            annot_vals = Set(values(getannotfile(single)))
+            @test any(occursin("filtercolumns! : 1 column has been", v) for v in annot_vals)
+
+            copy_all = seq[:]
+            @test isa(copy_all, AnnotatedSequence)
             @test getresidues(copy_all) == getresidues(seq)
         end
     end

--- a/test/MSA/Sequences.jl
+++ b/test/MSA/Sequences.jl
@@ -22,7 +22,9 @@
         @test size(seq) == (1, 20) # A sequence is stored as a 1xN matrix
         @test length(seq) == 20
         @test getindex(seq, 1) == Residue('A')
-        @test getindex(seq, 1:3) == res"ARN"
+        sub = getindex(seq, 1:3)
+        @test isa(sub, AnnotatedSequence)
+        @test getresidues(sub) == reshape(res"ARN", 1, 3)
         @test join(Char(res) for res in seq) == "ARNDCQEGHILKMFPSTWYV" # Iteration
     end
 


### PR DESCRIPTION
## Summary
- implement `getindex(::AnnotatedSequence, cols)` with annotation handling
- return a copy when slicing with `:` for annotated sequences
- ensure colon slicing works for annotated aligned sequences
- test colon slicing for `AnnotatedAlignedSequence`

## Testing
- `julia --project -e 'push!(LOAD_PATH,"test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("getindex")'`

------
https://chatgpt.com/codex/tasks/task_b_6865a6f5c380832da01789a4ef95ee95