### PR TITLE
Fix gzipped PDBML parsing

### DIFF
--- a/src/Utils/Read.jl
+++ b/src/Utils/Read.jl
@@ -88,20 +88,18 @@ function _read(
     kargs...,
 ) where {T<:FileFormat}
     check_file(filename)
-    if endswith(completename, ".xml.gz") || endswith(completename, ".xml")
-        document = LightXML.parse_file(filename)
-        try
-            parse_file(document, T, args...; kargs...)
-        finally
-            LightXML.free(document)
-        end
-    else
-        fh = open(filename, "r")
-        try
-            fh = endswith(completename, ".gz") ? GzipDecompressorStream(fh) : fh
+    open(filename, "r") do fh
+        fh = endswith(completename, ".gz") ? GzipDecompressorStream(fh) : fh
+        if endswith(completename, ".xml") || endswith(completename, ".xml.gz")
+            xml = read(fh, String)
+            document = LightXML.parse_string(xml)
+            try
+                parse_file(document, T, args...; kargs...)
+            finally
+                LightXML.free(document)
+            end
+        else
             parse_file(fh, T, args...; kargs...)
-        finally
-            close(fh)
         end
     end
 end


### PR DESCRIPTION
## Summary
- handle `.xml.gz` PDBML files by manually decompressing before XML parsing
- reduce duplication inside `_read`

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("Parse PDB and PDBML")'`

------
https://chatgpt.com/codex/tasks/task_b_68679f536370832dbfd17ce1b87f6bad