### PR TITLE
Fix gzipped PDBML parsing

### DIFF
--- a/src/SIFTS/ResidueMapping.jl
+++ b/src/SIFTS/ResidueMapping.jl
@@ -370,7 +370,20 @@ function siftsmapping(
     missings::Bool = true,
 ) where {F,T}
     mapping = OrderedDict{String,String}()
-    xdoc = LightXML.parse_file(filename)
+    xdoc = open(filename, "r") do fh
+        if endswith(filename, ".gz")
+            magic = read(fh, UInt16)
+            seek(fh, 0)
+            if magic == 0x1f8b || magic == 0x8b1f
+                fh = GzipDecompressorStream(fh)
+            end
+        end
+        if endswith(filename, ".xml") || endswith(filename, ".xml.gz")
+            LightXML.parse_string(read(fh, String))
+        else
+            LightXML.parse_file(fh)
+        end
+    end
     try
         for entity in _get_entities(xdoc)
             segments = _get_segments(entity)

--- a/src/SIFTS/SIFTS.jl
+++ b/src/SIFTS/SIFTS.jl
@@ -23,6 +23,7 @@ using AutoHashEquals
 using OrderedCollections
 using MIToS.Utils
 using ArgCheck
+using CodecZlib
 
 export DataBase,
     dbPDBe,

--- a/src/Utils/Read.jl
+++ b/src/Utils/Read.jl
@@ -88,20 +88,18 @@ function _read(
     kargs...,
 ) where {T<:FileFormat}
     check_file(filename)
-    if endswith(completename, ".xml.gz") || endswith(completename, ".xml")
-        document = LightXML.parse_file(filename)
-        try
-            parse_file(document, T, args...; kargs...)
-        finally
-            LightXML.free(document)
-        end
-    else
-        fh = open(filename, "r")
-        try
-            fh = endswith(completename, ".gz") ? GzipDecompressorStream(fh) : fh
+    open(filename, "r") do fh
+        fh = endswith(completename, ".gz") ? GzipDecompressorStream(fh) : fh
+        if endswith(completename, ".xml") || endswith(completename, ".xml.gz")
+            xml = read(fh, String)
+            document = LightXML.parse_string(xml)
+            try
+                parse_file(document, T, args...; kargs...)
+            finally
+                LightXML.free(document)
+            end
+        else
             parse_file(fh, T, args...; kargs...)
-        finally
-            close(fh)
         end
     end
 end


### PR DESCRIPTION
## Summary
- correctly decompress SIFTS XML files only when the gzip magic bytes are present
- import CodecZlib in the SIFTS module

## Testing
- `julia --project -e 'using MIToS.SIFTS; println(length(siftsmapping("test/data/2vqc.xml.gz", dbPDBe, "2vqc", dbPDB, "2vqc")))'`
- `julia --project -e 'using MIToS.SIFTS; println(length(siftsmapping("test/data/1H4A.xml.gz", dbPDBe, "1h4a", dbPDB, "1h4a")))'`


------
https://chatgpt.com/codex/tasks/task_b_68679f536370832dbfd17ce1b87f6bad