### PR TITLE
Add percent positive score

### DIFF
--- a/src/MSA/Identity.jl
+++ b/src/MSA/Identity.jl
@@ -264,3 +264,50 @@ function percentsimilarity(msa::AbstractMatrix{Residue}, A...; out::Type = Float
     end
     P
 end
+
+"""
+    percentpositive(seq1, seq2; matrix=ResidueSubstitutionMatrices.BLOSUM62)
+
+Return the percentage of positives (as defined by BLAST) between two
+aligned sequences. By default, the ``BLOSUM62`` substitution matrix is
+used, but an alternative ``matrix`` can be provided. Columns with gaps
+in both sequences are ignored. Residues not present in the substitution
+matrix, including ``XAA`` if absent, are treated as negatives but still
+count towards the alignment length.
+"""
+function percentpositive(
+    seq1::Vector{Residue},
+    seq2::Vector{Residue};
+    matrix::ResidueSubstitutionMatrices.ResidueSubstitutionMatrix{T,A} = ResidueSubstitutionMatrices.BLOSUM62,
+) where {T,A}
+    len = length(seq1)
+    if len != length(seq2)
+        throw(
+            ErrorException(
+                """
+Sequences of different lengths, they aren't aligned or don't come from the same MSA.
+""",
+            ),
+        )
+    end
+
+    count = 0
+    colgap = 0
+    alph = matrix.alphabet
+    @inbounds for i = 1:len
+        a = seq1[i]
+        b = seq2[i]
+        if a == GAP && b == GAP
+            colgap += 1
+            continue
+        end
+        if in(a, alph) && in(b, alph) && matrix[a, b] > 0
+            count += 1
+        end
+    end
+    alnlen = len - colgap
+    if alnlen == 0
+        return NaN
+    end
+    100.0 * count / alnlen
+end

--- a/src/MSA/MSA.jl
+++ b/src/MSA/MSA.jl
@@ -141,6 +141,7 @@ export  # Residue
     percentidentity,
     meanpercentidentity,
     percentsimilarity,
+    percentpositive,
     sum_of_pairs_score,
     # Clusters
     WeightTypes,

--- a/test/MSA/Identity.jl
+++ b/test/MSA/Identity.jl
@@ -216,4 +216,21 @@
             end
         end
     end
+
+    @testset "Percent Positives" begin
+        using MIToS.MSA.ResidueSubstitutionMatrices: BLOSUM62
+
+        @test percentpositive(res"AH", res"AH") == 100.0
+        @test percentpositive(res"AH", res"AH"; matrix = BLOSUM62) == 100.0
+        @test percentpositive(res"AV", res"AR") == 50.0
+        @test percentpositive(res"N", res"D") == 100.0
+        @test percentpositive(res"-A-", res"--H") == 0.0
+        @test percentpositive(res"XX", res"XX") == 0.0
+
+        ab = GappedAlphabet()
+        scores = Float64[i == j ? 1.0 : -1.0 for i = 1:length(ab), j = 1:length(ab)]
+        m = ResidueSubstitutionMatrices.ResidueSubstitutionMatrix(scores)
+        @test percentpositive(res"AX", res"AR"; matrix = m) == 50.0
+        @test percentpositive(res"XX", res"XX"; matrix = m) == 0.0
+    end
 end


### PR DESCRIPTION
## Summary
- add `percentpositive` function to compute BLAST-style positives with BLOSUM62 by default
- update export list and tests to use the new function

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("Identity")'`

------
https://chatgpt.com/codex/tasks/task_b_686a20644b14832da82b84d5c5876e0e