### PR TITLE
Add percent positive score

### DIFF
--- a/src/MSA/Identity.jl
+++ b/src/MSA/Identity.jl
@@ -26,6 +26,24 @@ function _percentidentity(seq1, seq2, len)
 end
 
 """
+_check_samelength(seq1, seq2)
+
+Verify that `seq1` and `seq2` have the same length. Return the common
+length or throw an `ErrorException` if the lengths are different.
+"""
+function _check_samelength(seq1, seq2)
+    len = length(seq1)
+    if len != length(seq2)
+        throw(
+            ErrorException(
+                "Sequences of different lengths, they aren't aligned or don't come from the same MSA.",
+            ),
+        )
+    end
+    len
+end
+
+"""
 `percentidentity(seq1, seq2)`
 
 Calculates the fraction of identities between two aligned sequences. The identity value is
@@ -35,14 +53,7 @@ count to the length of the sequences. Positions with a `XAA` in at least one seq
 aren't counted.
 """
 function percentidentity(seq1, seq2)
-    len = length(seq1)
-    if len != length(seq2)
-        throw(
-            ErrorException("""
-      Sequences of different length, they aren't aligned or don't come from the same MSA.
-      """),
-        )
-    end
+    len = _check_samelength(seq1, seq2)
     _percentidentity(seq1, seq2, len)
 end
 
@@ -56,14 +67,7 @@ sequence aren't counted.
 """
 function percentidentity(seq1, seq2, threshold)
     fraction = threshold / 100.0
-    len = length(seq1)
-    if len != length(seq2)
-        throw(
-            ErrorException("""
-      Sequences of different length, they aren't aligned or don't come from the same MSA.
-      """),
-        )
-    end
+    len = _check_samelength(seq1, seq2)
     n = len
     limit_count = n * fraction
     diff = 0
@@ -214,17 +218,7 @@ function percentsimilarity(
     seq2::Vector{Residue},
     alphabet::ResidueAlphabet = ReducedAlphabet("(AILMV)(RHK)(NQST)(DE)(FWY)CGP"),
 )
-
-    len = length(seq1)
-    if len != length(seq2)
-        throw(
-            ErrorException(
-                """
-Sequences of different lengths, they aren't aligned or don't come from the same MSA.
-""",
-            ),
-        )
-    end
+    len = _check_samelength(seq1, seq2)
 
     count = 0
     colgap = 0
@@ -261,6 +255,68 @@ function percentsimilarity(msa::AbstractMatrix{Residue}, A...; out::Type = Float
     P = sequencepairsmatrix(msa, out, Val{false}, out(100.0))
     @inbounds @iterateupper getarray(P) false begin
         list[k] = percentsimilarity(M[i], M[j], A...)
+    end
+    P
+end
+
+"""
+    percentpositive(seq1, seq2; matrix=ResidueSubstitutionMatrices.BLOSUM62)
+
+Return the percentage of positives (as in BLAST) between two
+aligned sequences. By default, the `BLOSUM62` substitution matrix is
+used, but an alternative `matrix` can be provided. Columns with gaps
+in both sequences are ignored. Residues not present in the substitution
+matrix, including `XAA` if absent, are treated as negatives but still
+count towards the alignment length.
+"""
+function _percentpositive(seq1, seq2, len, matrix)
+    count = 0
+    colgap = 0
+    alph = matrix.alphabet
+    @inbounds for i = 1:len
+        a = seq1[i]
+        b = seq2[i]
+        if a == GAP && b == GAP
+            colgap += 1
+            continue
+        end
+        if in(a, alph) && in(b, alph) && matrix[a, b] > 0
+            count += 1
+        end
+    end
+    alnlen = len - colgap
+    alnlen == 0 && return NaN
+    100.0 * count / alnlen
+end
+
+function percentpositive(
+    seq1::Vector{Residue},
+    seq2::Vector{Residue};
+    matrix::ResidueSubstitutionMatrices.ResidueSubstitutionMatrix{T,A} = ResidueSubstitutionMatrices.BLOSUM62,
+) where {T,A}
+    len = _check_samelength(seq1, seq2)
+    _percentpositive(seq1, seq2, len, matrix)
+end
+
+"""
+`percentpositive(msa[, out::Type=Float64]; matrix=ResidueSubstitutionMatrices.BLOSUM62)`
+
+Compute the percentage of positives (as in BLAST) between all pairs of
+sequences in a multiple sequence alignment `msa`. The default
+substitution `matrix` is `BLOSUM62`, but a different one can be passed.
+The output element type can be chosen with the `out` keyword argument
+(`Float64` by default).
+"""
+function percentpositive(
+    msa::AbstractMatrix{Residue},
+    out::Type = Float64;
+    matrix::ResidueSubstitutionMatrices.ResidueSubstitutionMatrix{T,A} = ResidueSubstitutionMatrices.BLOSUM62,
+) where {T,A}
+    M = getresiduesequences(msa)
+    len = length(M[1])
+    P = sequencepairsmatrix(msa, out, Val{false}, out(100.0))
+    @inbounds @iterateupper getarray(P) false begin
+        list[k] = _percentpositive(M[i], M[j], len, matrix)
     end
     P
 end

--- a/src/MSA/MSA.jl
+++ b/src/MSA/MSA.jl
@@ -141,6 +141,7 @@ export  # Residue
     percentidentity,
     meanpercentidentity,
     percentsimilarity,
+    percentpositive,
     sum_of_pairs_score,
     # Clusters
     WeightTypes,

--- a/test/MSA/Identity.jl
+++ b/test/MSA/Identity.jl
@@ -216,4 +216,40 @@
             end
         end
     end
+
+    @testset "Percent Positives" begin
+        using MIToS.MSA.ResidueSubstitutionMatrices: BLOSUM62
+
+        @test_throws ErrorException percentpositive(res"A", res"AA")
+
+        @test percentpositive(res"AH", res"AH") == 100.0
+        @test percentpositive(res"AH", res"AH"; matrix = BLOSUM62) == 100.0
+        @test percentpositive(res"AV", res"AR") == 50.0
+        @test percentpositive(res"N", res"D") == 100.0
+        @test percentpositive(res"-A-", res"--H") == 0.0
+        @test percentpositive(res"XX", res"XX") == 0.0
+
+        @test isnan(percentpositive(res"---", res"---"))
+
+        ab = GappedAlphabet()
+        scores = Float64[i == j ? 1.0 : -1.0 for i = 1:length(ab), j = 1:length(ab)]
+        m = ResidueSubstitutionMatrices.ResidueSubstitutionMatrix(scores)
+        @test percentpositive(res"AX", res"AR"; matrix = m) == 50.0
+        @test percentpositive(res"XX", res"XX"; matrix = m) == 0.0
+
+        @testset "Percent Positives MSA" begin
+            fasta = read_file(joinpath(DATA, "Gaoetal2011.fasta"), FASTA)
+            pp = percentpositive(fasta)
+
+            pp32 = percentpositive(fasta, Float32)
+
+            @test eltype(pp) == Float64
+            @test eltype(pp32) == Float32
+            @test pp[1, 1] == 100.0
+            @test isapprox(pp[1, 2], 83.33, atol = 0.01)
+            @test isapprox(pp[1, 4], 66.67, atol = 0.01)
+            @test isapprox(pp[4, 5], 83.33, atol = 0.01)
+            @test pp[5, 6] == 100.0
+        end
+    end
 end


### PR DESCRIPTION
## Summary
- add `_check_samelength` helper for pairwise sequence functions
- use the helper in identity and similarity routines
- add MSA method for `percentpositive` and corresponding tests
- make `matrix` a keyword for MSA percent positive and allow positional `out` argument
- refactor `percentpositive` to share length check logic with new `_percentpositive`

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("Identity")'`

------
https://chatgpt.com/codex/tasks/task_b_686a20644b14832da82b84d5c5876e0e