### PR TITLE
test: add peptide bond false case

### DIFF
--- a/test/PDB/Contacts.jl
+++ b/test/PDB/Contacts.jl
@@ -582,6 +582,8 @@
             @test ismissing(peptide_bond(residues[1], residues[1]))
             # residue[2] only has N; the first residue in the pair should provide C
             @test ismissing(peptide_bond(residues[2], residues[3]))
+            # residues[3] provides C and residues[2] provides N, but they are too far
+            @test !peptide_bond(residues[3], residues[2])
             # the atom pair has no C
             @test ismissing(
                 peptide_bond(


### PR DESCRIPTION
## Summary
- expand residue-level peptide bond tests to include a false case when residues are too far apart

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("Missing and false"); MIToSTests.retest("Missing and false")' 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68c007837788832dacbd7043b2771bb1