### PR TITLE
docs: deprecate covalentradius

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,13 @@
 
 Changes in the `PDB` module are:
 
-- *[Breaking change]* The values in `covalentradius` were modified to match those of 
+- *[Breaking change]* The values in `covalentradius` were modified to match those of
   Cordero et al. (2008) instead of the previously used values from Bickerton et al. (2011).
-- *[Breaking change]* The `covalent` function has been updated to return `true` 
-  when the distance between two atoms is less than or equal to the sum of their 
-  covalent radii, scaled by a new `tolerance_factor` keyword argument 
+- *[Breaking change]* The `covalentradius` constant has been deprecated in favor of the
+  `COVALENT_RADII` dictionary, which maps element symbols to their covalent radii.
+- *[Breaking change]* The `covalent` function has been updated to return `true`
+  when the distance between two atoms is less than or equal to the sum of their
+  covalent radii, scaled by a new `tolerance_factor` keyword argument
   (default: `1.1`).
 - *[Breaking change]* The `vanderwaalsradius` constant (with values from 
   Bickerton et al. 2011) has been deprecated in favor of the `VAN_DER_WAALS_RADII` 


### PR DESCRIPTION
## Summary
- note `covalentradius` deprecation in favor of `COVALENT_RADII` in release notes

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("PDB"); MIToSTests.retest("PDB")'` *(failed: Failed to precompile MIToSTests)*

------
https://chatgpt.com/codex/tasks/task_b_68c40d24456c832dbd2bfea0e257d298