### PR TITLE
Add function-first wrappers for non-mutating filters

### DIFF
--- a/src/MSA/MSAEditing.jl
+++ b/src/MSA/MSAEditing.jl
@@ -157,6 +157,14 @@ function filtersequences(
     filtersequences!(deepcopy(msa), args...)
 end
 
+function filtersequences(
+    f::Function,
+    msa::Union{AnnotatedMultipleSequenceAlignment,MultipleSequenceAlignment},
+    args...,
+)
+    filtersequences!(deepcopy(msa), f, args...)
+end
+
 # Filter columns
 # --------------
 
@@ -209,6 +217,10 @@ function filtercolumns!(f::Function, x::UnannotatedAlignedObject, annotate::Bool
 end
 
 filtercolumns(x::AbstractResidueMatrix, args...) = filtercolumns!(deepcopy(x), args...)
+
+function filtercolumns(f::Function, x::AbstractResidueMatrix, args...)
+    filtercolumns!(deepcopy(x), f, args...)
+end
 
 # Util function
 # -------------

--- a/test/MSA/MSAEditing.jl
+++ b/test/MSA/MSAEditing.jl
@@ -67,6 +67,11 @@
             @test filtersequences!(seq -> gapfraction(seq) < 0.5, copy_msa) ==
                   filtersequences(msa, seq -> gapfraction(seq) < 0.5)
         end
+
+        for msa in pfam_msas[3:4]
+            @test filtersequences(seq -> gapfraction(seq) < 0.5, msa) ==
+                  filtersequences(msa, seq -> gapfraction(seq) < 0.5)
+        end
     end
 
     @testset "filtercolumns!" begin
@@ -88,6 +93,11 @@
         for msa in pfam_msas[3:4]
             copy_msa = copy(msa)
             @test filtercolumns!(col -> gapfraction(col) < 0.5, copy_msa) ==
+                  filtercolumns(msa, col -> gapfraction(col) < 0.5)
+        end
+
+        for msa in pfam_msas[3:4]
+            @test filtercolumns(col -> gapfraction(col) < 0.5, msa) ==
                   filtercolumns(msa, col -> gapfraction(col) < 0.5)
         end
 
@@ -118,6 +128,11 @@
 
             @test filtercolumns!(col -> col[1] == Residue('Q'), copy(annseq)) ==
                   filtercolumns(annseq, col -> col[1] == Residue('Q'))
+
+            @test filtercolumns(col -> col[1] == Residue('Q'), annseq) ==
+                  filtercolumns(annseq, col -> col[1] == Residue('Q'))
+            @test filtercolumns(col -> col[1] == Residue('Q'), seq) ==
+                  filtercolumns(seq, col -> col[1] == Residue('Q'))
         end
     end
 


### PR DESCRIPTION
## Summary
- support `filtersequences` with function-first syntax
- add matching `filtercolumns` method and tests

## Testing
- `julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("MSA"); MIToSTests.retest("MSAEditing.jl"); MIToSTests.retest("MSAEditing.jl")'`

------
https://chatgpt.com/codex/tasks/task_b_68c40d73c0fc832dbd501b34f8a04b4b