### PR TITLE
Fix percentidentity threshold for XAA columns

### DIFF
--- a/src/MSA/Identity.jl
+++ b/src/MSA/Identity.jl
@@ -73,6 +73,7 @@ function percentidentity(seq1, seq2, threshold)
         aa2 = seq2[i]
         if aa1 == XAA || aa2 == XAA
             n -= 1
+            limit_count = n * fraction
             continue
         end
         if aa1 == aa2

--- a/test/MSA/Identity.jl
+++ b/test/MSA/Identity.jl
@@ -53,6 +53,10 @@
         @test percentidentity(res"AH-", res"AX-", 100.0)
         @test percentidentity(res"AH-", res"XG-", 0.0)
         @test !percentidentity(res"AGG", res"AHX", 62.0) # 50% < 62%
+        # Mixed XAA and mismatch columns should still reach the threshold once the
+        # ignored XAA positions are removed from the running length (2 matches out
+        # of 3 counted columns = 66%, not 2 / 4 = 50%).
+        @test percentidentity(res"AXAA", res"AAGA", 60.0)
     end
 
     @testset "MSA" begin


### PR DESCRIPTION
## Summary
- update `percentidentity` so the XAA branch keeps the mismatch threshold in sync when skipping ignored columns
- add a regression test covering mixed XAA and mismatches at a passing identity threshold
- clarify the regression test comment to note the 2/3 (66%) counted columns versus the ignored 2/4 (50%) length

## Testing
- `julia --project -e 'using Pkg; Pkg.test(coverage=true)'` *(fails: ftp.ebi.ac.uk connection error during SIFTS download)*
- `julia --project -e 'using Test, MIToS, MIToS.MSA; @testset begin @test percentidentity(res"AXAA", res"AAGA", 60.0) end'`

------
https://chatgpt.com/codex/tasks/task_b_68c9865c8fa4832d8722cc14f697d567