### PR TITLE
Streamline Stockholm annotation parsing tests, closes #168

### DIFF
--- a/src/MSA/Stockholm.jl
+++ b/src/MSA/Stockholm.jl
@@ -23,6 +23,14 @@ struct Stockholm <: MSAFormat end
     end
 end
 
+@inline function _append_annotation_fragment!(dict::AbstractDict, key, fragment)
+    if haskey(dict, key)
+        dict[key] = dict[key] * fragment
+    else
+        dict[key] = fragment
+    end
+end
+
 function _fill_with_line!(IDS, SEQS, GF, GS, GC, GR, line)
     if startswith(line, "#=GF")
         words = get_n_words(line, 3)
@@ -42,10 +50,12 @@ function _fill_with_line!(IDS, SEQS, GF, GS, GC, GR, line)
         end
     elseif startswith(line, "#=GC")
         words = get_n_words(line, 3)
-        GC[words[2]] = words[3]
+        _append_annotation_fragment!(GC, words[2], words[3])
     elseif startswith(line, "#=GR")
         words = get_n_words(line, 4)
-        GR[(words[2], words[3])] = words[4]
+        key = (words[2], words[3])
+        fragment = words[4]
+        _append_annotation_fragment!(GR, key, fragment)
     else
         _fill_with_sequence_line!(IDS, SEQS, line)
     end

--- a/test/MSA/IO.jl
+++ b/test/MSA/IO.jl
@@ -23,6 +23,7 @@
         pf09645_sto = joinpath(DATA, "PF09645_full.stockholm")
         rna_sto = joinpath(DATA, "upsk_rna.sto")
         clustal_sto = joinpath(DATA, "clustalo-I20240512-trunc.aln-stockholm")
+        hmmer_sto = joinpath(DATA, "hmmer_multiblock.sto")
 
         @testset "Read" begin
 
@@ -131,16 +132,11 @@
 
         @testset "File write Matrix{Residue}" begin
 
-            path = tempdir()
-            tmp_file = joinpath(path, ".tmp.stockholm")
-            try
+            mktemp() do tmp_file, tmp_io
+                close(tmp_io)
                 msa = read_file(pf09645_sto, Stockholm, Matrix{Residue})
                 write_file(tmp_file, msa, Stockholm)
                 @test read_file(tmp_file, Stockholm, Matrix{Residue}) == msa
-            finally
-                if isfile(tmp_file)
-                    rm(tmp_file)
-                end
             end
         end
 
@@ -159,6 +155,36 @@
                 print_file(io, msa, Stockholm)
                 printed = String(take!(io))
                 @test occursin(seq, printed)
+            end
+        end
+
+        @testset "HMMER multi-block annotations" begin
+
+            expected_rf = "xxxxxxxxxxxxxxxxxxxx......xxxxxxx......."
+            expected_ss_seq1 = "HHHHHHHHHHHHHHHHHHHHCCCCCCCCCCCCCCCCCCCC"
+            expected_ss_seq2 = "EEEEEEEEEEEEEEEEEEEEDDDDDDDDDDDDDDDDDDDD"
+
+            msa = read_file(hmmer_sto, Stockholm)
+            msa_keepinserts = read_file(hmmer_sto, Stockholm, keepinserts = true)
+
+            for alignment in (msa, msa_keepinserts)
+                @test getannotcolumn(alignment, "RF") == expected_rf
+                @test length(getannotcolumn(alignment, "RF")) == size(alignment, 2)
+                @test getannotresidue(alignment, "seq1", "SS") == expected_ss_seq1
+                @test getannotresidue(alignment, "seq2", "SS") == expected_ss_seq2
+            end
+
+            mktemp() do tmp_file, tmp_io
+                close(tmp_io)
+                write_file(tmp_file, msa, Stockholm)
+                roundtrip = read_file(tmp_file, Stockholm)
+                roundtrip_keepinserts = read_file(tmp_file, Stockholm, keepinserts = true)
+
+                for alignment in (roundtrip, roundtrip_keepinserts)
+                    @test getannotcolumn(alignment, "RF") == expected_rf
+                    @test getannotresidue(alignment, "seq1", "SS") == expected_ss_seq1
+                    @test getannotresidue(alignment, "seq2", "SS") == expected_ss_seq2
+                end
             end
         end
     end

--- a/test/data/hmmer_multiblock.sto
+++ b/test/data/hmmer_multiblock.sto
@@ -1,0 +1,13 @@
+# STOCKHOLM 1.0
+seq1            ACDEFGHIKLMNPQRSTVWY
+seq2            ACDEFGHIKLMNPQRSTVWY
+#=GC RF         xxxxxxxxxxxxxxxxxxxx
+#=GR seq1 SS    HHHHHHHHHHHHHHHHHHHH
+#=GR seq2 SS    EEEEEEEEEEEEEEEEEEEE
+
+seq1            ACDEFGHIKLMNPQRSTVWY
+seq2            ACDEFGHIKLMNPQRSTVWY
+#=GC RF         ......xxxxxxx.......
+#=GR seq1 SS    CCCCCCCCCCCCCCCCCCCC
+#=GR seq2 SS    DDDDDDDDDDDDDDDDDDDD
+//


### PR DESCRIPTION
## Summary
- call the annotation fragment helper directly when parsing GC metadata
- use `mktemp` when writing temporary Stockholm files in IO tests
- deduplicate HMMER multi-block annotation checks by iterating over the alignments

## Testing
- julia --project -e 'push!(LOAD_PATH, "test"); using MIToSTests; MIToSTests.retest("IO"); MIToSTests.retest("IO")'

------
https://chatgpt.com/codex/tasks/task_b_69028cfaef64832da76e03e9e13f987e