### PR TITLE
Update default RCSB download host

### DIFF
--- a/src/PDB/PDBMLParser.jl
+++ b/src/PDB/PDBMLParser.jl
@@ -159,7 +159,7 @@ _file_extension(format::Type{PDBFile}) = ".pdb.gz"
 It downloads a gzipped PDB file from PDB database.
 It requires a four character `pdbcode`.
 Its default `format` is `MMCIFFile` (mmCIF) and It uses the `baseurl`
-"http://www.rcsb.org/pdb/files/".
+"https://files.rcsb.org/download/".
 `filename` is the path/name of the output file.
 This function calls `MIToS.Utils.download_file` that calls `Downloads.download`. So, you
 can use keyword arguments, such as `headers`, from that function.
@@ -168,7 +168,7 @@ function downloadpdb(
     pdbcode::AbstractString;
     format::Type{T} = MMCIFFile,
     filename::AbstractString = uppercase(pdbcode) * _file_extension(format),
-    baseurl::AbstractString = "http://www.rcsb.org/pdb/files/",
+    baseurl::AbstractString = "https://files.rcsb.org/download/",
     kargs...,
 ) where {T<:FileFormat}
     if check_pdbcode(pdbcode)

--- a/test/Utils/GeneralUtils.jl
+++ b/test/Utils/GeneralUtils.jl
@@ -134,11 +134,11 @@ end
     end
 
     @testset "Download a gz file" begin
-        # Use https://www.rcsb.org/pdb/files/3NIR.pdb.gz to test downloading a gz file
+        # Use https://files.rcsb.org/download/3NIR.pdb.gz to test downloading a gz file
         # without a filename
         filename = ""
         try
-            filename = download_file("https://www.rcsb.org/pdb/files/3NIR.pdb.gz")
+            filename = download_file("https://files.rcsb.org/download/3NIR.pdb.gz")
             @test endswith(filename, ".gz")
             @test MIToS.Utils._check_gzip_file(filename) == filename
         finally


### PR DESCRIPTION
## Summary
- use the new files.rcsb.org download host as the default base URL for PDB downloads
- update download utility test to fetch gzipped PDB from the new host

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920264ca160832d8ba0f0c8c4b59199)