### PR TITLE
Add PSSM computation

### DIFF
--- a/src/Information/Information.jl
+++ b/src/Information/Information.jl
@@ -95,6 +95,10 @@ export  # MIToS.MSA
     BLMI,
     # PSSM
     AbstractPositionSpecificMatrix,
+    PositionFrequencyMatrix,
+    position_frequency_matrix,
+    PositionSpecificProbabilityMatrix,
+    position_specific_probability_matrix,
     PositionSpecificScoreMatrix,
     position_specific_scoring_matrix,
     # Gaps

--- a/src/Information/Information.jl
+++ b/src/Information/Information.jl
@@ -99,8 +99,10 @@ export  # MIToS.MSA
     position_frequency_matrix,
     PositionSpecificProbabilityMatrix,
     position_specific_probability_matrix,
-    PositionSpecificScoreMatrix,
+    PositionSpecificScoringMatrix,
     position_specific_scoring_matrix,
+    ProfileScore,
+    score_sequence,
     # Gaps
     gap_union_percentage,
     gap_intersection_percentage,

--- a/src/Information/Information.jl
+++ b/src/Information/Information.jl
@@ -95,7 +95,7 @@ export  # MIToS.MSA
     BLMI,
     # PSSM
     PSSMResult,
-    pssm,
+    position_specific_scoring_matrix,
     # Gaps
     gap_union_percentage,
     gap_intersection_percentage,

--- a/src/Information/Information.jl
+++ b/src/Information/Information.jl
@@ -94,7 +94,8 @@ export  # MIToS.MSA
     buslje09,
     BLMI,
     # PSSM
-    PSSMResult,
+    AbstractColumnScores,
+    PositionSpecificScoreMatrix,
     position_specific_scoring_matrix,
     # Gaps
     gap_union_percentage,

--- a/src/Information/Information.jl
+++ b/src/Information/Information.jl
@@ -94,7 +94,7 @@ export  # MIToS.MSA
     buslje09,
     BLMI,
     # PSSM
-    AbstractColumnScores,
+    AbstractPositionSpecificMatrix,
     PositionSpecificScoreMatrix,
     position_specific_scoring_matrix,
     # Gaps

--- a/src/Information/Information.jl
+++ b/src/Information/Information.jl
@@ -93,6 +93,9 @@ export  # MIToS.MSA
     # CorrectedMutualInformation
     buslje09,
     BLMI,
+    # PSSM
+    PSSMResult,
+    pssm,
     # Gaps
     gap_union_percentage,
     gap_intersection_percentage,
@@ -119,5 +122,6 @@ include("Corrections.jl")
 include("CorrectedMutualInformation.jl")
 include("Gaps.jl")
 include("Externals.jl")
+include("PSSM.jl")
 
 end

--- a/src/Information/InformationMeasures.jl
+++ b/src/Information/InformationMeasures.jl
@@ -191,11 +191,11 @@ function _gettablearray(
     gettablearray(table)
 end
 
-_gettablearray(table::Array{T,N}) where {T,N} = table
+_gettablearray(table::AbstractArray{T,N}) where {T,N} = table
 
 const _DOC_KL_KARG = """
 You can use the keyword argument `background` to set the background distribution. This 
-argument can take an `Array`, `Probabilities`, or `ContingencyTable` object. The background 
+argument can take an `AbstractArray`, `Probabilities`, or `ContingencyTable` object. The background 
 distribution must have the same size and alphabet as the probabilities. The default is the 
 `BLOSUM62_Pi` table. $_DOC_LOG_BASE
 """
@@ -234,9 +234,10 @@ end
 # Kullback-Leibler for MSA
 
 """
-    kullback_leibler(msa::AbstractArray{Residue}; background::Union{Array{T,N}, Probabilities{T,N,A}, ContingencyTable{T,N,A}}=BLOSUM62_Pi, base::Number=ℯ, kargs...)
+    kullback_leibler(msa::AbstractArray{Residue}; background::AbstractArray=BLOSUM62_Pi, base::Number=ℯ, rank::Int=1, kargs...)
 
 It calculates the Kullback-Leibler (KL) divergence from a multiple sequence alignment (MSA).
+Currently, `rank` must be `1`.
 $_DOC_KL_KARG The other keyword arguments are passed to the [`mapfreq`](@ref) function.
 """
 function kullback_leibler(

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -20,49 +20,36 @@ struct PSSMResult{T,A}
     base::Float64
 end
 
-@inline function _collect_background(background, alphabet::ResidueAlphabet)
-    values =
-        if background isa Probabilities || background isa ContingencyTable
-            gettablearray(background)
-        else
-            background
-        end
-    vector = Float64.(vec(values))
-    length(vector) == length(alphabet) ||
-        throw(ArgumentError("Background length $(length(vector)) doesn't match alphabet length $(length(alphabet))."))
-    total = sum(vector)
-    total > 0 || throw(ArgumentError("Background distribution sums to zero."))
-    if total != 1
+function _collect_background(background::AbstractArray, alphabet::ResidueAlphabet)
+    values = _gettablearray(background)
+    n_values = length(values)
+    n_ab = length(alphabet)
+    if n_values != n_ab
+        throw(
+            ArgumentError(
+                "Background length $n_values doesn't match alphabet length $n_ab.",
+            ),
+        )
+    end
+    vector = Vector{Float64}(undef, n_ab)
+    total = 0.0
+    @inbounds for (i, val) in enumerate(values)
+        value = Float64(val)
+        isfinite(value) ||
+            throw(DomainError(value, "Background values must be finite Float64 values."))
+        value ≥ 0 || throw(
+            DomainError(value, "Background values must be nonnegative Float64 values."),
+        )
+        vector[i] = value
+        total += value
+    end
+    if !(total > 0)
+        throw(DomainError(total, "Background distribution must have positive sum."))
+    end
+    if total != 1.0
         vector ./= total
     end
     vector
-end
-
-@inline function _log_odds(
-    p::Float64,
-    q::Float64,
-    zero_policy::Symbol,
-    use_log2::Bool,
-    invlogbase::Float64,
-    epsT::Float64,
-)
-    if zero_policy === :clamp
-        p = max(p, epsT)
-        q = max(q, epsT)
-    elseif zero_policy === :error
-        (p > 0 && q > 0) || throw(DomainError((p, q), "Zero probability encountered."))
-    else
-        # zero_policy === :negInf
-        if p == 0 && q == 0
-            return NaN
-        elseif p == 0
-            return -Inf
-        elseif q == 0
-            return Inf
-        end
-    end
-    ratio = p / q
-    use_log2 ? log2(ratio) : log(ratio) * invlogbase
 end
 
 """
@@ -73,21 +60,26 @@ MIToS probability estimation. Scores are returned as a matrix with rows ordered 
 provided alphabet and columns corresponding to alignment positions.
 
 # Keywords
-- `dims::Int = 2`: compute scores per column. Other values throw an `ArgumentError`.
-- `alphabet = UngappedAlphabet()`: residue alphabet; score rows follow this order.
-- `weights = NoClustering()`: sequence weights used during probability estimation.
-- `pseudocounts = NoPseudocount()`: pseudocounts applied before normalization.
-- `background = BLOSUM62_Pi`: background distribution `q(a)`; accepts vectors,
-  `Probabilities` or `ContingencyTable` objects. It is normalized if needed.
-- `base::Number = 2`: logarithm base (e.g., 2 for bits).
-- `gap_handling::Symbol = :skip`: if `:skip`, gaps are ignored when the alphabet includes
-  them; if `:include`, gaps are scored using their observed frequency.
-- `zero_policy::Symbol = :negInf`: handling of zero probabilities. `:negInf` produces
-  `-Inf`, `Inf` or `NaN`; `:error` throws; `:clamp` replaces zeros with `eps`.
-- `all_gap_value = NaN`: value used for every residue in columns with no valid
-  observations after applying the gap policy.
+
+  - `dims::Int = 2`: compute scores per column. Other values throw an `ArgumentError`.
+  - `alphabet = UngappedAlphabet()`: residue alphabet; score rows follow this order.
+  - `weights = NoClustering()`: sequence weights used during probability estimation.
+  - `pseudocounts = NoPseudocount()`: pseudocounts applied before normalization.
+  - `background = BLOSUM62_Pi`: background distribution `q(a)`; accepts `AbstractArray`,
+    `Probabilities` or `ContingencyTable` objects. It is normalized if needed.
+  - `base::Number = 2`: logarithm base (e.g., 2 for bits).
+
+Gaps are handled by the chosen `alphabet`: `UngappedAlphabet()` ignores gaps, while
+`GappedAlphabet()` includes them.
+
+Scores are computed directly as log-odds, so IEEE floating-point rules apply for zeros
+(`-Inf`, `Inf`, or `NaN`).
+
+Columns with no valid observations (e.g. all gaps using `UngappedAlphabet()`) are filled
+with `NaN`.
 
 # Examples
+
 ```julia
 using MIToS.Information, MIToS.MSA
 
@@ -103,15 +95,8 @@ function pssm(
     pseudocounts::Pseudocount = NoPseudocount(),
     background = BLOSUM62_Pi,
     base::Number = 2,
-    gap_handling::Symbol = :skip,
-    zero_policy::Symbol = :negInf,
-    all_gap_value = NaN,
 )
     dims == 2 || throw(ArgumentError("pssm supports dims=2 (per-column) only."))
-    gap_handling in (:skip, :include) ||
-        throw(ArgumentError("Unsupported gap_handling = $(gap_handling)."))
-    zero_policy in (:negInf, :error, :clamp) ||
-        throw(ArgumentError("Unsupported zero_policy = $(zero_policy)."))
     base_val = Float64(base)
     (base_val > 0) && (base_val != 1) ||
         throw(ArgumentError("Base must be positive and different from 1."))
@@ -123,27 +108,17 @@ function pssm(
     scores = Matrix{Float64}(undef, nres, ncols)
 
     column_table = ContingencyTable(Float64, Val{1}, alphabet)
-    gap_index = alphabet[GAP]
-    include_gap = gap_handling === :include || gap_index > nres
     use_log2 = base_val == 2
     invlogbase = use_log2 ? 1.0 : inv(log(base_val))
-    epsT = eps(Float64)
-
-    freq_array = gettablearray(column_table)
 
     @inbounds for j = 1:ncols
         cleanup!(column_table)
         col_view = @view msa[:, j]
         frequencies!(column_table, col_view; weights = weights, pseudocounts = pseudocounts)
 
-        if !include_gap && gap_index <= nres
-            freq_array[gap_index] = 0.0
-            update_marginals!(column_table)
-        end
-
         total = gettotal(column_table)
         if total == 0
-            scores[:, j] .= all_gap_value
+            scores[:, j] .= NaN
             continue
         end
 
@@ -152,7 +127,8 @@ function pssm(
         for i = 1:nres
             p = prob_view[i]
             qi = q[i]
-            scores[i, j] = _log_odds(p, qi, zero_policy, use_log2, invlogbase, epsT)
+            ratio = p / qi
+            scores[i, j] = use_log2 ? log2(ratio) : log(ratio) * invlogbase
         end
     end
 

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -25,14 +25,21 @@ function _collect_background(background::AbstractArray, alphabet::ResidueAlphabe
     n_values = length(values)
     n_ab = length(alphabet)
     if n_values != n_ab
-        throw(ArgumentError("Background length $n_values doesn't match alphabet length $n_ab."))
+        throw(
+            ArgumentError(
+                "Background length $n_values doesn't match alphabet length $n_ab.",
+            ),
+        )
     end
     vector = Vector{Float64}(undef, n_ab)
     total = 0.0
     @inbounds for (i, val) in enumerate(values)
         value = Float64(val)
-        isfinite(value) || throw(DomainError(value, "Background values must be finite Float64 values."))
-        value ≥ 0 || throw(DomainError(value, "Background values must be nonnegative Float64 values."))
+        isfinite(value) ||
+            throw(DomainError(value, "Background values must be finite Float64 values."))
+        value ≥ 0 || throw(
+            DomainError(value, "Background values must be nonnegative Float64 values."),
+        )
         vector[i] = value
         total += value
     end
@@ -54,7 +61,6 @@ provided alphabet and columns corresponding to alignment positions.
 
 # Keywords
 
-  - `dims::Int = 2`: compute scores per column. Other values throw an `ArgumentError`.
   - `alphabet = UngappedAlphabet()`: residue alphabet; score rows follow this order.
   - `weights = NoClustering()`: sequence weights used during probability estimation.
   - `pseudocounts = NoPseudocount()`: pseudocounts applied before normalization.
@@ -82,22 +88,21 @@ result = pssm(msa; background = fill(1 / 20, 20))
 """
 function pssm(
     msa::AbstractArray{Residue};
-    dims::Int = 2,
     alphabet::ResidueAlphabet = UngappedAlphabet(),
     weights::WeightTypes = NoClustering(),
     pseudocounts::Pseudocount = NoPseudocount(),
     background = BLOSUM62_Pi,
     base::Number = 2,
 )
-    dims == 2 || throw(ArgumentError("pssm supports dims=2 (per-column) only."))
     base_val = Float64(base)
-    (base_val > 0) && (base_val != 1) ||
-        throw(ArgumentError("Base must be positive and different from 1."))
+    if (base_val < 0.0) || (base_val == 1.0)
+        throw(ArgumentError("The logarithm base must be positive and different from 1."))
+    end
 
     q = _collect_background(background, alphabet)
 
     nres = length(alphabet)
-    ncols = size(msa, 2)
+    ncols = ncolumns(msa)
     scores = Matrix{Float64}(undef, nres, ncols)
 
     column_table = ContingencyTable(Float64, Val{1}, alphabet)

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -4,7 +4,7 @@
 # Abstract Types
 # ==============
 
-abstract type AbstractColumnScores{T,N,A} <: AbstractArray{T,N} end
+abstract type AbstractPositionSpecificMatrix{T,N,A} <: AbstractArray{T,N} end
 
 # Result Type
 # ===========
@@ -20,7 +20,7 @@ Result returned by [`position_specific_scoring_matrix`](@ref), containing the lo
 `table` is a `NamedArray` whose rows follow the provided `alphabet` ordering and whose columns
 match the alignment positions.
 """
-struct PositionSpecificScoreMatrix{T,A} <: AbstractColumnScores{T,2,A}
+struct PositionSpecificScoreMatrix{T,A} <: AbstractPositionSpecificMatrix{T,2,A}
     table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
     base::Union{Irrational{:ℯ}, Float64, Int}
@@ -29,22 +29,26 @@ end
 # Getters
 # -------
 
-@inline getalphabet(scores::AbstractColumnScores) = scores.alphabet
-@inline gettable(scores::AbstractColumnScores) = scores.table
-@inline gettablearray(scores::AbstractColumnScores) = getarray(gettable(scores))
+@inline getalphabet(scores::AbstractPositionSpecificMatrix) = scores.alphabet
+@inline gettable(scores::AbstractPositionSpecificMatrix) = scores.table
+@inline gettablearray(scores::AbstractPositionSpecificMatrix) = getarray(gettable(scores))
 
 # AbstractArray
 # -------------
 
 for f in (:size, :getindex)
-    @eval Base.$(f)(scores::AbstractColumnScores, args...) =
+    @eval Base.$(f)(scores::AbstractPositionSpecificMatrix, args...) =
         $(f)(gettable(scores), args...)
 end
 
 # Show
 # ----
 
-function Base.show(io::IO, ::MIME"text/plain", scores::AbstractColumnScores)
+function Base.show(
+    io::IO,
+    ::MIME"text/plain",
+    scores::PositionSpecificScoreMatrix,
+)
     base_val = scores.base
     unit =
         base_val == ℯ ? "nats" : base_val == 2 ? "bits" : base_val == 10 ? "hartleys" :

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -9,7 +9,7 @@
         base::Float64
     end
 
-Result returned by [`pssm`](@ref), containing the log-odds scores for a protein PSSM.
+Result returned by [`position_specific_scoring_matrix`](@ref), containing the log-odds scores for a protein PSSM.
 `scores` is a matrix whose rows follow the provided `alphabet` ordering and whose columns
 match the alignment positions.
 """
@@ -53,7 +53,7 @@ function _collect_background(background::AbstractArray, alphabet::ResidueAlphabe
 end
 
 """
-    pssm(msa::AbstractArray{Residue}; kwargs...) -> PSSMResult
+    position_specific_scoring_matrix(msa::AbstractArray{Residue}; kwargs...) -> PSSMResult
 
 Compute a log-odds position-specific scoring matrix (PSSM) from a protein MSA using
 MIToS probability estimation. Scores are returned as a matrix with rows ordered by the
@@ -66,7 +66,9 @@ provided alphabet and columns corresponding to alignment positions.
   - `pseudocounts = NoPseudocount()`: pseudocounts applied before normalization.
   - `background = BLOSUM62_Pi`: background distribution `q(a)`; accepts `AbstractArray`,
     `Probabilities` or `ContingencyTable` objects. It is normalized if needed.
-  - `base::Number = 2`: logarithm base (e.g., 2 for bits).
+  - `base::Number = ℯ`: logarithm base.
+
+Use the keyword argument `base` to change the base of the log. $_DOC_LOG_BASE
 
 Gaps are handled by the chosen `alphabet`: `UngappedAlphabet()` ignores gaps, while
 `GappedAlphabet()` includes them.
@@ -83,20 +85,23 @@ with `NaN`.
 using MIToS.Information, MIToS.MSA
 
 msa = permutedims(hcat(res"AC", res"AD", res"AE")) # three sequences, two positions
-result = pssm(msa; background = fill(1 / 20, 20))
+result = position_specific_scoring_matrix(msa; background = fill(1 / 20, 20))
 ```
 """
-function pssm(
+function position_specific_scoring_matrix(
     msa::AbstractArray{Residue};
     alphabet::ResidueAlphabet = UngappedAlphabet(),
     weights::WeightTypes = NoClustering(),
     pseudocounts::Pseudocount = NoPseudocount(),
     background = BLOSUM62_Pi,
-    base::Number = 2,
+    base::Number = ℯ,
 )
-    base_val = Float64(base)
-    if (base_val < 0.0) || (base_val == 1.0)
-        throw(ArgumentError("The logarithm base must be positive and different from 1."))
+    if !(base > 0) || base == 1 # this also catches NaN
+        throw(
+            ArgumentError(
+                "The logarithm base must be positive and different from 1 (base=$base).",
+            ),
+        )
     end
 
     q = _collect_background(background, alphabet)
@@ -106,29 +111,24 @@ function pssm(
     scores = Matrix{Float64}(undef, nres, ncols)
 
     column_table = ContingencyTable(Float64, Val{1}, alphabet)
-    use_log2 = base_val == 2
-    invlogbase = use_log2 ? 1.0 : inv(log(base_val))
+    invlogbase = base === ℯ ? 1.0 : inv(log(base))
 
-    @inbounds for j = 1:ncols
+    for j = 1:ncols
         cleanup!(column_table)
-        col_view = @view msa[:, j]
+        col_view = @inbounds @view msa[:, j]
+        # counts:
         frequencies!(column_table, col_view; weights = weights, pseudocounts = pseudocounts)
-
-        total = gettotal(column_table)
-        if total == 0
-            scores[:, j] .= NaN
-            continue
-        end
-
+        # probabilities:
         normalize!(column_table)
-        prob_view = gettablearray(column_table)
-        for i = 1:nres
-            p = prob_view[i]
+        P = gettablearray(column_table)
+        # log-odds scores:
+        @inbounds for i = 1:nres
+            p = P[i]
             qi = q[i]
             ratio = p / qi
-            scores[i, j] = use_log2 ? log2(ratio) : log(ratio) * invlogbase
+            scores[i, j] = invlogbase == 1.0 ? log(ratio) : log(ratio) * invlogbase
         end
     end
 
-    PSSMResult(scores, alphabet, q, base_val)
+    PSSMResult(scores, alphabet, q, Float64(base))
 end

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -1,32 +1,74 @@
 # Position-Specific Scoring Matrix (PSSM)
 # =======================================
 
+# Abstract Types
+# ==============
+
+abstract type AbstractColumnScores{T,N,A} <: AbstractArray{T,N} end
+
+# Result Type
+# ===========
+
 """
-    struct PSSMResult{T,A}
-        scores::Matrix{T}
+    struct PositionSpecificScoreMatrix{T,A}
+        table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
         alphabet::A
         background::Vector{Float64}
         base::Union{Irrational{:ℯ}, Float64, Int}
     end
 
 Result returned by [`position_specific_scoring_matrix`](@ref), containing the log-odds scores for a protein PSSM.
-`scores` is a matrix whose rows follow the provided `alphabet` ordering and whose columns
+`table` is a `NamedArray` whose rows follow the provided `alphabet` ordering and whose columns
 match the alignment positions.
 """
-struct PSSMResult{T,A}
-    scores::Matrix{T}
+struct PositionSpecificScoreMatrix{T,A} <: AbstractColumnScores{T,2,A}
+    table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
     background::Vector{Float64}
-    base::Union{Irrational{:ℯ},Float64,Int}
+    base::Union{Irrational{:ℯ}, Float64, Int}
 end
 
-# helpers to mostly use Float64 for bases, but keeping ℯ and 2 as is
+# Getters
+# -------
+
+@inline getalphabet(scores::AbstractColumnScores) = scores.alphabet
+@inline gettable(scores::AbstractColumnScores) = scores.table
+@inline gettablearray(scores::AbstractColumnScores) = getarray(gettable(scores))
+
+# AbstractArray
+# -------------
+
+for f in (:size, :getindex)
+    @eval Base.$(f)(scores::AbstractColumnScores, args...) =
+        $(f)(gettable(scores), args...)
+end
+
+# Show
+# ----
+
+function Base.show(io::IO, ::MIME"text/plain", scores::AbstractColumnScores)
+    print(io, typeof(scores), " : ")
+    print(io, "\ntable : ")
+    show(io, MIME"text/plain"(), gettable(scores))
+end
+
+# Base Conversion
+# ---------------
+
 @inline _convert_base(base::Irrational{:ℯ}) = base
 @inline _convert_base(base::Int) = base
-@inline _convert_base(base::Number) = Float64(base)
-@inline function _convert_base(base::Integer) # promote to Int if possible
-    base <= typemax(Int) ? Int(base) : Float64(base) # base should be positive
+
+@inline function _convert_base(base::Integer)
+    if base >= 0 && base <= typemax(Int)
+        return Int(base)
+    end
+    Float64(base)
 end
+
+@inline _convert_base(base::Number) = Float64(base)
+
+# Background Collection
+# ---------------------
 
 function _collect_background(background::AbstractArray, alphabet::ResidueAlphabet)
     values = _gettablearray(background)
@@ -60,12 +102,15 @@ function _collect_background(background::AbstractArray, alphabet::ResidueAlphabe
     vector
 end
 
+# PSSM
+# ====
+
 """
-    position_specific_scoring_matrix(msa::AbstractArray{Residue}; kwargs...) -> PSSMResult
+    position_specific_scoring_matrix(msa::AbstractArray{Residue}; kwargs...) -> PositionSpecificScoreMatrix
 
 Compute a log-odds position-specific scoring matrix (PSSM) from a protein MSA using
-MIToS probability estimation. Scores are returned as a matrix with rows ordered by the
-provided alphabet and columns corresponding to alignment positions.
+MIToS probability estimation. Scores are returned as a `NamedArray` with rows ordered by
+the provided alphabet and columns corresponding to alignment positions.
 
 # Keywords
 
@@ -131,13 +176,19 @@ function position_specific_scoring_matrix(
         normalize!(column_table)
         P = gettablearray(column_table)
         # log-odds scores:
-        @inbounds for i = 1:nres
-            p = P[i]
-            qi = q[i]
+        for i = 1:nres
+            p = @inbounds P[i]
+            qi = @inbounds q[i]
             ratio = p / qi
-            scores[i, j] = invlogbase == 1.0 ? log(ratio) : log(ratio) * invlogbase
+            @inbounds scores[i, j] =
+                invlogbase == 1.0 ? log(ratio) : log(ratio) * invlogbase
         end
     end
 
-    PSSMResult(scores, alphabet, q, base_val)
+    row_dict = getnamedict(alphabet)
+    col_names = columnnames(msa)
+    col_dict = OrderedDict{String,Int}(col_names[i] => i for i = 1:ncols)
+    table = NamedArray(scores, (row_dict, col_dict), ("Residue", "Col"))
+
+    PositionSpecificScoreMatrix(table, alphabet, q, base_val)
 end

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -1,6 +1,36 @@
 # Position-Specific Scoring Matrix (PSSM)
 # =======================================
 
+# Docstring reusable parts
+# ------------------------
+
+const _LOG_BASE_UNITS = string(
+    "Units follow the log base: base=2 yields bits, ",
+    "base=ℯ yields nats, base=10 yields hartleys.",
+)
+
+const _DOC_PROFILE_SHAPE = string(
+    "rows following the provided alphabet ordering and ",
+    "columns corresponding to alignment positions.",
+)
+
+const _DOC_MSA_KWARGS = """
+  - `alphabet = UngappedAlphabet()`: residue alphabet defining the row order.
+  - `weights = NoClustering()`: sequence weights to reduce redundancy.
+  - `pseudocounts = NoPseudocount()`: smoothing applied before normalization.
+"""
+const _DOC_PSSM_FORMULA = string(
+    "``Sᵢ(a) = log_b(pᵢ(a) / q(a))``, where i is the alignment column, ",
+    "a is a residue symbol in the alphabet, pᵢ(a) is the PSPM probability at ",
+    "that column, q(a) is the background probability for residue a, and b is ",
+    "the log base.",
+)
+const _DOC_PSPM_FORMULA = string(
+    "``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment column, ",
+    "a is a residue symbol in the alphabet, and ``∑ₐ`` sums over all residues in ",
+    "that alphabet.",
+)
+
 # Abstract Types
 # ==============
 
@@ -15,12 +45,8 @@ Concrete subtypes represent three stages of a profile:
 
   - PFM ([`PositionFrequencyMatrix`](@ref)): ``fᵢ(a)`` is the (possibly weighted and
     pseudocounted) count of residue a in column i.
-  - PSPM ([`PositionSpecificProbabilityMatrix`](@ref)): ``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``,
-    where i is the alignment column, a is a residue symbol in the alphabet, and ``∑ₐ``
-    sums over all residues in that alphabet.
-  - PSSM ([`PositionSpecificScoreMatrix`](@ref)): ``Sᵢ(a) = log_b(pᵢ(a) / q(a))``, where
-    q(a) is the background probability for residue a and b is the log base (units are
-    described in the PSSM docstring).
+  - PSPM ([`PositionSpecificProbabilityMatrix`](@ref)): $(_DOC_PSPM_FORMULA)
+  - PSSM ([`PositionSpecificScoringMatrix`](@ref)): $(_DOC_PSSM_FORMULA)
 
 These profiles summarize column composition and can be used to score aligned sequences.
 """
@@ -40,10 +66,10 @@ each residue at each alignment position. So that ``fᵢ(a)`` is the (possibly we
 pseudocounted) count of residue a in column i. Weights can down-weight redundant sequences,
 and pseudocounts smooth columns with sparse observations.
 A `PositionFrequencyMatrix` is a subtype of [`AbstractPositionSpecificMatrix`](@ref). That
-stores the frequency matrix in the `table` field. `table` is a `NamedArray` whose rows
-follow the provided `alphabet` ordering and whose columns correspond to alignment positions.
+stores the frequency matrix in the `table` field. `table` is a `NamedArray` with
+$(_DOC_PROFILE_SHAPE).
 """
-struct PositionFrequencyMatrix{A} <: AbstractPositionSpecificMatrix{A}
+mutable struct PositionFrequencyMatrix{A} <: AbstractPositionSpecificMatrix{A}
     table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
 end
@@ -55,44 +81,171 @@ end
     end
 
 Position-specific probability matrix (PSPM). Each column is a probability distribution
-over the alphabet at a position: ``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment
-column, a is a residue symbol in the alphabet, and ``∑ₐ`` sums over all residues in that
-alphabet. Columns are normalized independently; if a column has zero total weight (for
-example, an all-gap column under an ungapped alphabet), that column is filled with `NaN`.
+over the alphabet at a position: $(_DOC_PSPM_FORMULA) Columns are normalized independently;
+if a column has zero total weight (for example, an all-gap column under an ungapped
+alphabet), that column is filled with `NaN`.
 """
-struct PositionSpecificProbabilityMatrix{A} <: AbstractPositionSpecificMatrix{A}
+mutable struct PositionSpecificProbabilityMatrix{A} <: AbstractPositionSpecificMatrix{A}
     table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
 end
 
 """
-    struct PositionSpecificScoreMatrix{A}
+    struct PositionSpecificScoringMatrix{A}
         table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
         alphabet::A
         base::Union{Irrational{:ℯ}, Float64, Int}
     end
 
 Position-specific scoring matrix (PSSM) with log-odds scores relative to a background
-distribution. Scores are defined as ``Sᵢ(a) = log_b(pᵢ(a) / q(a))``, where i is the
-alignment column, a is a residue symbol in the alphabet, pᵢ(a) is the PSPM probability,
-q(a) is the background probability for residue a, and b is the log base.
+distribution. Scores are defined as $(_DOC_PSSM_FORMULA)
 
 Positive scores indicate enrichment over background; negative scores indicate depletion.
-The `base` field controls units: b = 2 yields bits, b = ℯ yields nats, and b = 10 yields
-hartleys. IEEE floating-point rules apply for zeros (pᵢ(a) = 0 ⇒ `-Inf`, q(a) = 0 ⇒
-`Inf`, invalid ratios ⇒ `NaN`).
+The `base` field controls units. $(_LOG_BASE_UNITS) IEEE floating-point rules apply for
+zeros (pᵢ(a) = 0 ⇒ `-Inf`, q(a) = 0 ⇒ `Inf`, invalid ratios ⇒ `NaN`).
 
 To score an aligned sequence x of length n_positions, you can sum per-position scores:
 ``score(x) = ∑ᵢ Sᵢ(xᵢ)``, where xᵢ is the residue observed at position i.
 
-`table` is a `NamedArray` whose rows follow the provided `alphabet` ordering and whose
-columns match the alignment positions.
+`table` is a `NamedArray` with $(_DOC_PROFILE_SHAPE).
 """
-struct PositionSpecificScoreMatrix{A} <: AbstractPositionSpecificMatrix{A}
+mutable struct PositionSpecificScoringMatrix{A} <: AbstractPositionSpecificMatrix{A}
     table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
     base::Union{Irrational{:ℯ},Float64,Int}
 end
+
+# Constructors
+# ============
+
+# Helpers: Arguments
+# ------------------
+
+@inline function _check_matrix_nrows(data::AbstractMatrix, alphabet::ResidueAlphabet)
+    nrows = size(data, 1)
+    nrows == length(alphabet) || throw(
+        ArgumentError(
+            "Row count ($nrows) doesn't match alphabet length ($(length(alphabet))).",
+        ),
+    )
+end
+
+# Helpers: Log Base
+# -----------------
+
+@inline function _check_log_base(base::Number)
+    if !(base > 0) || base == 1 # this also catches NaN
+        throw(
+            ArgumentError(
+                "The logarithm base must be positive and different from 1 (base=$base).",
+            ),
+        )
+    end
+end
+
+@inline _convert_base(base::Irrational{:ℯ}) = base
+@inline _convert_base(base::Int) = base
+
+@inline function _convert_base(base::Integer)
+    if base >= 0 && base <= typemax(Int)
+        return Int(base)
+    end
+    Float64(base)
+end
+
+@inline _convert_base(base::Number) = Float64(base)
+
+# NamedArray constructors (main)
+# ------------------------------
+
+function PositionFrequencyMatrix(
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}},
+    alphabet::A,
+) where {A<:ResidueAlphabet}
+    _check_matrix_nrows(table, alphabet)
+    PositionFrequencyMatrix{A}(table, alphabet)
+end
+
+function PositionSpecificProbabilityMatrix(
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}},
+    alphabet::A,
+) where {A<:ResidueAlphabet}
+    _check_matrix_nrows(table, alphabet)
+    PositionSpecificProbabilityMatrix{A}(table, alphabet)
+end
+
+function PositionSpecificScoringMatrix(
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}},
+    alphabet::A,
+    base::Union{Irrational{:ℯ},Float64,Int},
+) where {A<:ResidueAlphabet}
+    _check_log_base(base)
+    _check_matrix_nrows(table, alphabet)
+    PositionSpecificScoringMatrix{A}(table, alphabet, base)
+end
+
+function PositionSpecificScoringMatrix(
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}},
+    alphabet::A,
+    base::Number = ℯ,
+) where {A<:ResidueAlphabet}
+    PositionSpecificScoringMatrix(table, alphabet, _convert_base(base))
+end
+
+
+# Matrix constructors (AbstractMatrix -> NamedArray)
+# --------------------------------------------------
+
+function _named_matrix(data::AbstractMatrix, alphabet::ResidueAlphabet)
+    ncols = size(data, 2)
+    row_dict = getnamedict(alphabet)
+    col_dict = OrderedDict{String,Int}(string(i) => i for i = 1:ncols)
+    NamedArray(Matrix{Float64}(data), (row_dict, col_dict), ("Res", "Col"))
+end
+
+PositionFrequencyMatrix(data::AbstractMatrix, alphabet::ResidueAlphabet) =
+    PositionFrequencyMatrix(_named_matrix(data, alphabet), alphabet)
+
+PositionSpecificProbabilityMatrix(data::AbstractMatrix, alphabet::ResidueAlphabet) =
+    PositionSpecificProbabilityMatrix(_named_matrix(data, alphabet), alphabet)
+
+function PositionSpecificScoringMatrix(
+    data::AbstractMatrix,
+    alphabet::ResidueAlphabet,
+    base::Number = ℯ,
+)
+    PositionSpecificScoringMatrix(_named_matrix(data, alphabet), alphabet, base)
+end
+
+# Size-based constructors (ncol -> Matrix)
+# ----------------------------------------
+
+PositionFrequencyMatrix(alphabet::ResidueAlphabet, ncols::Int) =
+    PositionFrequencyMatrix(zeros(Float64, length(alphabet), ncols), alphabet)
+
+PositionSpecificProbabilityMatrix(alphabet::ResidueAlphabet, ncols::Int) =
+    PositionSpecificProbabilityMatrix(fill(NaN, length(alphabet), ncols), alphabet)
+
+function PositionSpecificScoringMatrix(
+    alphabet::ResidueAlphabet,
+    ncols::Int,
+    base::Number = ℯ,
+)
+    PositionSpecificScoringMatrix(zeros(Float64, length(alphabet), ncols), alphabet, base)
+end
+
+# Convenience constructors
+# ------------------------
+
+Base.zeros(::Type{PositionFrequencyMatrix}, alphabet::ResidueAlphabet, ncols::Int) =
+    PositionFrequencyMatrix(alphabet, ncols)
+
+Base.zeros(
+    ::Type{PositionSpecificScoringMatrix},
+    alphabet::ResidueAlphabet,
+    ncols::Int,
+    base::Number = ℯ,
+) = PositionSpecificScoringMatrix(alphabet, ncols, base)
 
 # Getters
 # -------
@@ -109,6 +262,9 @@ for f in (:size, :getindex)
         $(f)(gettable(scores), args...)
 end
 
+Base.setindex!(scores::AbstractPositionSpecificMatrix, v, args...) =
+    setindex!(gettable(scores), v, args...)
+
 @inline function Base.getindex(scores::AbstractPositionSpecificMatrix, r::Residue, c::Int)
     i = scores.alphabet[r]
     table = gettablearray(scores)
@@ -116,10 +272,22 @@ end
     @inbounds table[i, c]
 end
 
+@inline function Base.setindex!(
+    scores::AbstractPositionSpecificMatrix,
+    v,
+    r::Residue,
+    c::Int,
+)
+    i = scores.alphabet[r]
+    table = gettablearray(scores)
+    @boundscheck checkbounds(table, i, c)
+    @inbounds table[i, c] = v
+end
+
 # Show
 # ----
 
-function Base.show(io::IO, ::MIME"text/plain", scores::PositionSpecificScoreMatrix)
+function Base.show(io::IO, ::MIME"text/plain", scores::PositionSpecificScoringMatrix)
     base_val = scores.base
     unit =
         base_val == ℯ ? "nats" :
@@ -144,21 +312,6 @@ function Base.show(io::IO, ::MIME"text/plain", ppm::PositionSpecificProbabilityM
     print(io, "\ntable : ")
     show(io, MIME"text/plain"(), gettable(ppm))
 end
-
-# Base Conversion
-# ---------------
-
-@inline _convert_base(base::Irrational{:ℯ}) = base
-@inline _convert_base(base::Int) = base
-
-@inline function _convert_base(base::Integer)
-    if base >= 0 && base <= typemax(Int)
-        return Int(base)
-    end
-    Float64(base)
-end
-
-@inline _convert_base(base::Number) = Float64(base)
 
 # Background Collection
 # ---------------------
@@ -242,8 +395,7 @@ ungapped alphabet ignores gaps while a gapped alphabet treats the gap as a symbo
 
 # Returns
 
-[`PositionFrequencyMatrix`](@ref) with rows in alphabet order and columns matching
-alignment positions.
+[`PositionFrequencyMatrix`](@ref) with $(_DOC_PROFILE_SHAPE).
 """
 function position_frequency_matrix(
     msa::AbstractArray{Residue};
@@ -282,23 +434,19 @@ end
 
 Build a position-specific probability matrix (PSPM). Internally, it converts a PFM
 (position frequency matrix) into a PSPM by column-wise normalization using
-``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment column, a is a residue symbol in
-the alphabet, and ``∑ₐ`` sums over all residues in that alphabet. When built from an MSA,
-the PFM is computed first using the provided keyword arguments.
+$(_DOC_PSPM_FORMULA) When built from an MSA, the PFM is computed first using the provided
+keyword arguments.
 
 If a column has zero total weight (e.g., all gaps under an ungapped alphabet), that
 column is filled with `NaN`.
 
 # Keyword Arguments
 
-  - `alphabet = UngappedAlphabet()`: residue alphabet defining the row order.
-  - `weights = NoClustering()`: sequence weights to reduce redundancy.
-  - `pseudocounts = NoPseudocount()`: smoothing applied before normalization.
+$(_DOC_MSA_KWARGS)
 
 # Returns
 
-[`PositionSpecificProbabilityMatrix`](@ref) with rows in alphabet order and columns
-matching alignment positions.
+[`PositionSpecificProbabilityMatrix`](@ref) with $(_DOC_PROFILE_SHAPE).
 """
 function position_specific_probability_matrix(pfm::PositionFrequencyMatrix)
     table = deepcopy(pfm.table)
@@ -331,19 +479,16 @@ end
     position_specific_scoring_matrix(ppm::PositionSpecificProbabilityMatrix; kwargs...)
 
 Compute a position-specific scoring matrix (PSSM) with log-odds scores
-``Sᵢ(a) = log_b(pᵢ(a) / q(a))``. Here i is the alignment column, a is a residue symbol in
-the alphabet, pᵢ(a) is the PSPM probability at that column, q(a) is the background
-probability for residue a, and b is the log base. The PSSM can be built from an MSA, a
-position frequency matrix (PFM), or a position-specific probability matrix (PSPM).
+$(_DOC_PSSM_FORMULA) The PSSM can be built from an MSA, a position frequency matrix (PFM),
+or a position-specific probability matrix (PSPM).
 
 Positive scores indicate enrichment over background; negative scores indicate depletion.
 PSSMs are used to score sequences against a profile.
 
 # Keyword Arguments
 
-  - `alphabet = UngappedAlphabet()`: residue alphabet; score rows follow this order.
-  - `weights = NoClustering()`: sequence weights used during probability estimation.
-  - `pseudocounts = NoPseudocount()`: pseudocounts applied before normalization.
+$(_DOC_MSA_KWARGS)
+
   - `background = BLOSUM62_Pi`: background distribution `q(a)`; accepts `AbstractArray`,
     `Probabilities` or `ContingencyTable` objects. It is normalized if needed.
   - `base::Number = ℯ`: logarithm base.
@@ -360,13 +505,11 @@ observations (e.g. all gaps using `UngappedAlphabet()`) are filled with `NaN`.
 
 # Notes
 
-The base controls units: b = 2 yields bits, b = ℯ yields nats, and b = 10 yields
-hartleys.
+$(_LOG_BASE_UNITS)
 
 # Results
 
-[`PositionSpecificScoreMatrix`](@ref) with rows in alphabet order and columns matching
-alignment positions.
+[`PositionSpecificScoringMatrix`](@ref) with $(_DOC_PROFILE_SHAPE).
 
 # Examples
 
@@ -399,13 +542,7 @@ function position_specific_scoring_matrix(
     background = BLOSUM62_Pi,
     base::Number = ℯ,
 )
-    if !(base > 0) || base == 1 # this also catches NaN
-        throw(
-            ArgumentError(
-                "The logarithm base must be positive and different from 1 (base=$base).",
-            ),
-        )
-    end
+    _check_log_base(base)
 
     q = _collect_background(background, ppm.alphabet)
     table = deepcopy(ppm.table)
@@ -423,7 +560,7 @@ function position_specific_scoring_matrix(
         end
     end
 
-    PositionSpecificScoreMatrix(table, ppm.alphabet, _convert_base(base))
+    PositionSpecificScoringMatrix(table, ppm.alphabet, _convert_base(base))
 end
 
 function position_specific_scoring_matrix(
@@ -434,3 +571,169 @@ function position_specific_scoring_matrix(
     ppm = position_specific_probability_matrix(pfm)
     position_specific_scoring_matrix(ppm; background = background, base = base)
 end
+
+# Sequence Scoring
+# ================
+
+@doc """
+    score_sequence(pssm::PositionSpecificScoringMatrix, seq::AbstractVector{Residue})
+    score_sequence(pssm::PositionSpecificScoringMatrix, seqs::AbstractMatrix{Residue})
+    score_sequence(ppm::PositionSpecificProbabilityMatrix, seq::AbstractVector{Residue}; base = ℯ)
+    score_sequence(ppm::PositionSpecificProbabilityMatrix, seqs::AbstractMatrix{Residue}; base = ℯ)
+
+Score sequences against a profile.
+
+The result is a [`ProfileScore`](@ref) with `score`, `kind`, `base`, and `used_positions`
+(count of non-gap residues of the sequence that are present in the alphabet). For PSSMs
+([`PositionSpecificScoringMatrix`](@ref)), `score` is the sum of per-position log-odds
+scores (`kind = :log_odds`). For PSPMs ([`PositionSpecificProbabilityMatrix`](@ref)), 
+`score` is the log-likelihood (`kind = :log_likelihood`), computed as the sum of the log
+probabilities of the observed residues under the profile. The `base` is the log base used
+to compute the scores.
+
+$(_LOG_BASE_UNITS)
+
+Useful transformations of the log-likelihood (`score` when `kind == :log_likelihood`) for 
+the sequence under the PSPM (here, `used_positions` is how many positions were scored, and 
+`base` is the log base used to compute the `score`):
+
+- The **Average log-likelihood (per position)** is a length-normalized score you can 
+  compare across sequences of different lengths: `score / used_positions`
+- The **Geometric mean probability (per position)** is a "typical per-position probability" 
+  derived from the average log-likelihood: `base^(score / used_positions)`
+- The **Likelihood** is the probability of the whole sequence under the PSPM (this may 
+  underflow for long sequences, so prefer using `score`): `base^score`
+
+Residues not present in the profile alphabet are skipped. Non-gap residues that are
+missing from the alphabet emit one warning per residue/alphabet pair.
+""" score_sequence
+
+"""
+    ProfileScore(score, kind, base, used_positions)
+
+Container for `score_sequence` results. `score` is a log-odds or log-likelihood sum,
+`kind` is `:log_odds` or `:log_likelihood`, `base` is the logarithm base used for the
+score, and `used_positions` counts the residues that were present in the profile
+alphabet.
+
+$(_LOG_BASE_UNITS)
+"""
+struct ProfileScore
+    score::Float64
+    kind::Symbol
+    base::Union{Irrational{:ℯ},Float64,Int}
+    used_positions::Int
+end
+
+function _warn_unknown_residue(res::Residue, alphabet::ResidueAlphabet)
+    @warn "Residue $res not in alphabet $(typeof(alphabet)); skipping." maxlog = 1 _id =
+        (:score_sequence, res, join(names(alphabet), ','))
+end
+
+function _check_sequence_length(psm::AbstractPositionSpecificMatrix, seq)
+    ncols = size(psm, 2)
+    nres = length(seq)
+    if nres != ncols
+        throw(ArgumentError("Sequence length $nres doesn't match profile length $ncols."))
+    end
+    ncols
+end
+
+function _sequence_vec(seq::AbstractMatrix{Residue})
+    if size(seq, 1) != 1 && size(seq, 2) != 1
+        throw(
+            ArgumentError(string(
+                "A sequence must be represented as a matrix with a singleton dimension, ",
+                "but got size $(size(seq)).",)
+            ),
+        )
+    end
+    vec(seq)
+end
+
+function _alphabet_index(res::Residue, alphabet::ResidueAlphabet)
+    if res in alphabet
+        return alphabet[res]
+    end
+    if res != GAP
+        _warn_unknown_residue(res, alphabet)
+    end
+    0
+end
+
+function _score_sequence_kernel(
+    table::AbstractMatrix{Float64},
+    alphabet::ResidueAlphabet,
+    seq::AbstractVector{Residue},
+    ::Val{log_scores},
+    invlogbase::Float64,
+) where {log_scores}
+    score = 0.0
+    used_positions = 0
+    @inbounds for i = 1:length(seq)
+        idx = _alphabet_index(seq[i], alphabet)
+        if idx != 0
+            used_positions += 1
+            value = table[idx, i]
+            if log_scores
+                score += log(value) * invlogbase
+            else
+                score += value
+            end
+        end
+    end
+    score, used_positions
+end
+
+function _score_sequence(pssm::PositionSpecificScoringMatrix, seq::AbstractVector{Residue})
+    _check_sequence_length(pssm, seq)
+    alphabet = pssm.alphabet
+    table = gettablearray(pssm)
+    score, used_positions = _score_sequence_kernel(table, alphabet, seq, Val(false), 1.0)
+    ProfileScore(score, :log_odds, pssm.base, used_positions)
+end
+
+function _score_sequence(pssm::PositionSpecificScoringMatrix, seqs::AbstractMatrix{Residue})
+    _score_sequence(pssm, _sequence_vec(seqs))
+end
+
+function _score_sequence(
+    ppm::PositionSpecificProbabilityMatrix,
+    seq::AbstractVector{Residue};
+    base::Number = ℯ,
+)
+    _check_log_base(base)
+    base_val = _convert_base(base)
+    _check_sequence_length(ppm, seq)
+    alphabet = ppm.alphabet
+    table = gettablearray(ppm)
+    invlogbase = base_val === ℯ ? 1.0 : inv(log(base_val))
+    score, used_positions = _score_sequence_kernel(table, alphabet, seq, Val(true), invlogbase)
+    ProfileScore(score, :log_likelihood, base_val, used_positions)
+end
+
+function _score_sequence(
+    ppm::PositionSpecificProbabilityMatrix,
+    seqs::AbstractMatrix{Residue};
+    base::Number = ℯ,
+)
+    _score_sequence(ppm, _sequence_vec(seqs); base = base)
+end
+
+score_sequence(pssm::PositionSpecificScoringMatrix, seq::AbstractVector{Residue}) =
+    _score_sequence(pssm, seq)
+
+score_sequence(pssm::PositionSpecificScoringMatrix, seqs::AbstractMatrix{Residue}) =
+    _score_sequence(pssm, seqs)
+
+score_sequence(
+    ppm::PositionSpecificProbabilityMatrix,
+    seq::AbstractVector{Residue};
+    base::Number = ℯ,
+) = _score_sequence(ppm, seq; base = base)
+
+score_sequence(
+    ppm::PositionSpecificProbabilityMatrix,
+    seqs::AbstractMatrix{Residue};
+    base::Number = ℯ,
+) = _score_sequence(ppm, seqs; base = base)

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -4,24 +4,91 @@
 # Abstract Types
 # ==============
 
-abstract type AbstractPositionSpecificMatrix{T,N,A} <: AbstractArray{T,N} end
+"""
+    AbstractPositionSpecificMatrix{A}
 
-# Result Type
-# ===========
+Abstract supertype for position-wise residue profiles derived from a protein MSA. These
+profiles are matrix-like with shape (n_residues × n_positions), where rows follow the
+chosen residue alphabet and columns correspond to alignment positions.
+
+Concrete subtypes represent three stages of a profile:
+  - PFM ([`PositionFrequencyMatrix`](@ref)): ``fᵢ(a)`` is the (possibly weighted and
+    pseudocounted) count of residue a in column i.
+  - PSPM ([`PositionSpecificProbabilityMatrix`](@ref)): ``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``,
+    where i is the alignment column, a is a residue symbol in the alphabet, and ``∑ₐ``
+    sums over all residues in that alphabet.
+  - PSSM ([`PositionSpecificScoreMatrix`](@ref)): ``Sᵢ(a) = log_b(pᵢ(a) / q(a))``, where
+    q(a) is the background probability for residue a and b is the log base (units are
+    described in the PSSM docstring).
+
+These profiles summarize column composition and can be used to score aligned sequences.
+"""
+abstract type AbstractPositionSpecificMatrix{A} <: AbstractArray{Float64,2} end
+
+# Result Types
+# ============
 
 """
-    struct PositionSpecificScoreMatrix{T,A}
-        table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
+    struct PositionFrequencyMatrix{A}
+        table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
+        alphabet::A
+    end
+
+Position frequency matrix (PFM) for a protein MSA representing the frequencies/counts of
+each residue at each alignment position. So that ``fᵢ(a)`` is the (possibly weighted and 
+pseudocounted) count of residue a in column i. Weights can down-weight redundant sequences, 
+and pseudocounts smooth columns with sparse observations. 
+A `PositionFrequencyMatrix` is a subtype of [`AbstractPositionSpecificMatrix`](@ref). That 
+stores the frequency matrix in the `table` field. `table` is a `NamedArray` whose rows 
+follow the provided `alphabet` ordering and whose columns correspond to alignment positions.
+"""
+struct PositionFrequencyMatrix{A} <: AbstractPositionSpecificMatrix{A}
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
+    alphabet::A
+end
+
+"""
+    struct PositionSpecificProbabilityMatrix{A}
+        table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
+        alphabet::A
+    end
+
+Position-specific probability matrix (PSPM). Each column is a probability distribution
+over the alphabet at a position: ``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment
+column, a is a residue symbol in the alphabet, and ``∑ₐ`` sums over all residues in that
+alphabet. Columns are normalized independently; if a column has zero total weight (for
+example, an all-gap column under an ungapped alphabet), that column is filled with `NaN`.
+"""
+struct PositionSpecificProbabilityMatrix{A} <: AbstractPositionSpecificMatrix{A}
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
+    alphabet::A
+end
+
+"""
+    struct PositionSpecificScoreMatrix{A}
+        table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
         alphabet::A
         base::Union{Irrational{:ℯ}, Float64, Int}
     end
 
-Result returned by [`position_specific_scoring_matrix`](@ref), containing the log-odds scores for a protein PSSM.
-`table` is a `NamedArray` whose rows follow the provided `alphabet` ordering and whose columns
-match the alignment positions.
+Position-specific scoring matrix (PSSM) with log-odds scores relative to a background
+distribution. Scores are defined as ``Sᵢ(a) = log_b(pᵢ(a) / q(a))``, where i is the
+alignment column, a is a residue symbol in the alphabet, pᵢ(a) is the PSPM probability,
+q(a) is the background probability for residue a, and b is the log base.
+
+Positive scores indicate enrichment over background; negative scores indicate depletion.
+The `base` field controls units: b = 2 yields bits, b = ℯ yields nats, and b = 10 yields
+hartleys. IEEE floating-point rules apply for zeros (pᵢ(a) = 0 ⇒ `-Inf`, q(a) = 0 ⇒
+`Inf`, invalid ratios ⇒ `NaN`).
+
+To score an aligned sequence x of length n_positions, you can sum per-position scores:
+``score(x) = ∑ᵢ Sᵢ(xᵢ)``, where xᵢ is the residue observed at position i.
+
+`table` is a `NamedArray` whose rows follow the provided `alphabet` ordering and whose
+columns match the alignment positions.
 """
-struct PositionSpecificScoreMatrix{T,A} <: AbstractPositionSpecificMatrix{T,2,A}
-    table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
+struct PositionSpecificScoreMatrix{A} <: AbstractPositionSpecificMatrix{A}
+    table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
     base::Union{Irrational{:ℯ}, Float64, Int}
 end
@@ -60,6 +127,18 @@ function Base.show(
     print(io, " : ")
     print(io, "\ntable : ")
     show(io, MIME"text/plain"(), gettable(scores))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", pfm::PositionFrequencyMatrix)
+    print(io, typeof(pfm), " : ")
+    print(io, "\ntable : ")
+    show(io, MIME"text/plain"(), gettable(pfm))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ppm::PositionSpecificProbabilityMatrix)
+    print(io, typeof(ppm), " : ")
+    print(io, "\ntable : ")
+    show(io, MIME"text/plain"(), gettable(ppm))
 end
 
 # Base Conversion
@@ -112,15 +191,149 @@ function _collect_background(background::AbstractArray, alphabet::ResidueAlphabe
     vector
 end
 
-# PSSM
-# ====
+# Frequencies
+# ===========
+
+function _position_frequency_matrix(
+    msa::AbstractArray{Residue};
+    alphabet::ResidueAlphabet = UngappedAlphabet(),
+    weights::WeightTypes = NoClustering(),
+    pseudocounts::Pseudocount = NoPseudocount(),
+)
+    nres = length(alphabet)
+    ncols = ncolumns(msa)
+    frequencies = Matrix{Float64}(undef, nres, ncols)
+
+    column_table = ContingencyTable(Float64, Val{1}, alphabet)
+
+    for j = 1:ncols
+        cleanup!(column_table)
+        col_view = @inbounds @view msa[:, j]
+        frequencies!(column_table, col_view; weights = weights, pseudocounts = pseudocounts)
+        @inbounds frequencies[:, j] .= gettablearray(column_table)
+    end
+
+    row_dict = getnamedict(alphabet)
+    col_names = columnnames(msa)
+    col_dict = OrderedDict{String,Int}(col_names[i] => i for i = 1:ncols)
+    NamedArray(frequencies, (row_dict, col_dict), ("Res", "Col"))
+end
 
 """
-    position_specific_scoring_matrix(msa::AbstractArray{Residue}; kwargs...) -> PositionSpecificScoreMatrix
+    position_frequency_matrix(msa::AbstractArray{Residue}; kwargs...)
 
-Compute a log-odds position-specific scoring matrix (PSSM) from a protein MSA using
-MIToS probability estimation. Scores are returned as a `NamedArray` with rows ordered by
-the provided alphabet and columns corresponding to alignment positions.
+Compute a position frequency matrix (PFM) from a protein MSA. Each column summarizes how
+often each residue appears at that alignment position. Therefore, for column i and residue
+a, ``fᵢ(a)`` is the (possibly weighted and pseudocounted) count of that residue in that
+column. The `weights` reduce redundancy in highly similar MSAs (so closely related 
+sequences do not dominate), and `pseudocounts` smooth sparse columns to avoid zero 
+frequencies. The chosen `alphabet` defines which symbols are counted; for example, an 
+ungapped alphabet ignores gaps while a gapped alphabet treats the gap as a symbol.
+
+# Keyword Arguments
+
+  - `alphabet = UngappedAlphabet()`: residue alphabet defining the row order.
+  - `weights = NoClustering()`: sequence weights to reduce redundancy.
+  - `pseudocounts = NoPseudocount()`: smoothing applied before normalization.
+
+# Returns
+
+[`PositionFrequencyMatrix`](@ref) with rows in alphabet order and columns matching 
+alignment positions.
+"""
+function position_frequency_matrix(
+    msa::AbstractArray{Residue};
+    alphabet::ResidueAlphabet = UngappedAlphabet(),
+    weights::WeightTypes = NoClustering(),
+    pseudocounts::Pseudocount = NoPseudocount(),
+)
+    table = _position_frequency_matrix(
+        msa;
+        alphabet = alphabet,
+        weights = weights,
+        pseudocounts = pseudocounts,
+    )
+    PositionFrequencyMatrix(table, alphabet)
+end
+
+# Probabilities
+# ============
+
+function _normalize_position_probabilities!(matrix::AbstractMatrix)
+    @inbounds for j = 1:size(matrix, 2)
+        col = @view matrix[:, j]
+        total = sum(col)
+        if total == 0.0
+            fill!(col, NaN)
+        elseif total != 1.0
+            col ./= total
+        end
+    end
+    matrix
+end
+
+"""
+    position_specific_probability_matrix(pfm::PositionFrequencyMatrix)
+    position_specific_probability_matrix(msa::AbstractArray{Residue}; kwargs...)
+
+Build a position-specific probability matrix (PSPM). Internally, it converts a PFM 
+(position frequency matrix) into a PSPM by column-wise normalization using 
+``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment column, a is a residue symbol in 
+the alphabet, and ``∑ₐ`` sums over all residues in that alphabet. When built from an MSA,
+the PFM is computed first using the provided keyword arguments.
+
+If a column has zero total weight (e.g., all gaps under an ungapped alphabet), that
+column is filled with `NaN`.
+
+# Keyword Arguments
+
+  - `alphabet = UngappedAlphabet()`: residue alphabet defining the row order.
+  - `weights = NoClustering()`: sequence weights to reduce redundancy.
+  - `pseudocounts = NoPseudocount()`: smoothing applied before normalization.
+
+# Returns
+
+[`PositionSpecificProbabilityMatrix`](@ref) with rows in alphabet order and columns
+matching alignment positions.
+"""
+function position_specific_probability_matrix(pfm::PositionFrequencyMatrix)
+    table = deepcopy(pfm.table)
+    _normalize_position_probabilities!(getarray(table))
+    PositionSpecificProbabilityMatrix(table, pfm.alphabet)
+end
+
+function position_specific_probability_matrix(
+    msa::AbstractArray{Residue};
+    alphabet::ResidueAlphabet = UngappedAlphabet(),
+    weights::WeightTypes = NoClustering(),
+    pseudocounts::Pseudocount = NoPseudocount(),
+)
+    table = _position_frequency_matrix(
+        msa;
+        alphabet = alphabet,
+        weights = weights,
+        pseudocounts = pseudocounts,
+    )
+    _normalize_position_probabilities!(getarray(table))
+    PositionSpecificProbabilityMatrix(table, alphabet)
+end
+
+# Scoring
+# =======
+
+"""
+    position_specific_scoring_matrix(msa::AbstractArray{Residue}; kwargs...)
+    position_specific_scoring_matrix(pfm::PositionFrequencyMatrix; kwargs...)
+    position_specific_scoring_matrix(ppm::PositionSpecificProbabilityMatrix; kwargs...)
+
+Compute a position-specific scoring matrix (PSSM) with log-odds scores
+``Sᵢ(a) = log_b(pᵢ(a) / q(a))``. Here i is the alignment column, a is a residue symbol in
+the alphabet, pᵢ(a) is the PSPM probability at that column, q(a) is the background
+probability for residue a, and b is the log base. The PSSM can be built from an MSA, a
+position frequency matrix (PFM), or a position-specific probability matrix (PSPM).
+
+Positive scores indicate enrichment over background; negative scores indicate depletion.
+PSSMs are used to score sequences against a profile.
 
 # Keywords
 
@@ -134,13 +347,17 @@ the provided alphabet and columns corresponding to alignment positions.
 Use the keyword argument `base` to change the base of the log. $_DOC_LOG_BASE
 
 Gaps are handled by the chosen `alphabet`: `UngappedAlphabet()` ignores gaps, while
-`GappedAlphabet()` includes them.
+`GappedAlphabet()` includes them. The `background` distribution must match the alphabet
+length and is normalized if needed.
 
-Scores are computed directly as log-odds, so IEEE floating-point rules apply for zeros
-(`-Inf`, `Inf`, or `NaN`).
+Scores are computed directly as log-odds, so IEEE floating-point rules apply for zeros:
+pᵢ(a) = 0 ⇒ `-Inf`, q(a) = 0 ⇒ `Inf`, invalid ratios ⇒ `NaN`. Columns with no valid
+observations (e.g. all gaps using `UngappedAlphabet()`) are filled with `NaN`.
 
-Columns with no valid observations (e.g. all gaps using `UngappedAlphabet()`) are filled
-with `NaN`.
+# Notes
+
+The base controls units: b = 2 yields bits, b = ℯ yields nats, and b = 10 yields
+hartleys.
 
 # Examples
 
@@ -148,7 +365,7 @@ with `NaN`.
 using MIToS.Information, MIToS.MSA
 
 msa = permutedims(hcat(res"AC", res"AD", res"AE")) # three sequences, two positions
-result = position_specific_scoring_matrix(msa; background = fill(1 / 20, 20))
+result = position_specific_scoring_matrix(msa)
 ```
 """
 function position_specific_scoring_matrix(
@@ -156,6 +373,20 @@ function position_specific_scoring_matrix(
     alphabet::ResidueAlphabet = UngappedAlphabet(),
     weights::WeightTypes = NoClustering(),
     pseudocounts::Pseudocount = NoPseudocount(),
+    background = BLOSUM62_Pi,
+    base::Number = ℯ,
+)
+    ppm = position_specific_probability_matrix(
+        msa;
+        alphabet = alphabet,
+        weights = weights,
+        pseudocounts = pseudocounts,
+    )
+    position_specific_scoring_matrix(ppm; background = background, base = base)
+end
+
+function position_specific_scoring_matrix(
+    ppm::PositionSpecificProbabilityMatrix;
     background = BLOSUM62_Pi,
     base::Number = ℯ,
 )
@@ -167,37 +398,31 @@ function position_specific_scoring_matrix(
         )
     end
 
-    q = _collect_background(background, alphabet)
-
-    nres = length(alphabet)
-    ncols = ncolumns(msa)
-    scores = Matrix{Float64}(undef, nres, ncols)
-
-    column_table = ContingencyTable(Float64, Val{1}, alphabet)
+    q = _collect_background(background, ppm.alphabet)
+    table = deepcopy(ppm.table)
+    X = getarray(table)
+    nrows = size(X, 1)
+    ncols = size(X, 2)
     invlogbase = base === ℯ ? 1.0 : inv(log(base))
 
     for j = 1:ncols
-        cleanup!(column_table)
-        col_view = @inbounds @view msa[:, j]
-        # counts:
-        frequencies!(column_table, col_view; weights = weights, pseudocounts = pseudocounts)
-        # probabilities:
-        normalize!(column_table)
-        P = gettablearray(column_table)
-        # log-odds scores:
-        for i = 1:nres
-            p = @inbounds P[i]
+        for i = 1:nrows
+            p = @inbounds X[i, j]
             qi = @inbounds q[i]
             ratio = p / qi
-            @inbounds scores[i, j] =
+            @inbounds X[i, j] =
                 invlogbase == 1.0 ? log(ratio) : log(ratio) * invlogbase
         end
     end
 
-    row_dict = getnamedict(alphabet)
-    col_names = columnnames(msa)
-    col_dict = OrderedDict{String,Int}(col_names[i] => i for i = 1:ncols)
-    table = NamedArray(scores, (row_dict, col_dict), ("Res", "Col"))
+    PositionSpecificScoreMatrix(table, ppm.alphabet, _convert_base(base))
+end
 
-    PositionSpecificScoreMatrix(table, alphabet, _convert_base(base))
+function position_specific_scoring_matrix(
+    pfm::PositionFrequencyMatrix;
+    background = BLOSUM62_Pi,
+    base::Number = ℯ,
+)
+    ppm = position_specific_probability_matrix(pfm)
+    position_specific_scoring_matrix(ppm; background = background, base = base)
 end

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -25,21 +25,14 @@ function _collect_background(background::AbstractArray, alphabet::ResidueAlphabe
     n_values = length(values)
     n_ab = length(alphabet)
     if n_values != n_ab
-        throw(
-            ArgumentError(
-                "Background length $n_values doesn't match alphabet length $n_ab.",
-            ),
-        )
+        throw(ArgumentError("Background length $n_values doesn't match alphabet length $n_ab."))
     end
     vector = Vector{Float64}(undef, n_ab)
     total = 0.0
     @inbounds for (i, val) in enumerate(values)
         value = Float64(val)
-        isfinite(value) ||
-            throw(DomainError(value, "Background values must be finite Float64 values."))
-        value ≥ 0 || throw(
-            DomainError(value, "Background values must be nonnegative Float64 values."),
-        )
+        isfinite(value) || throw(DomainError(value, "Background values must be finite Float64 values."))
+        value ≥ 0 || throw(DomainError(value, "Background values must be nonnegative Float64 values."))
         vector[i] = value
         total += value
     end
@@ -83,7 +76,7 @@ with `NaN`.
 ```julia
 using MIToS.Information, MIToS.MSA
 
-msa = hcat(res"AC", res"AD", res"AE")' # three sequences, two positions
+msa = permutedims(hcat(res"AC", res"AD", res"AE")) # three sequences, two positions
 result = pssm(msa; background = fill(1 / 20, 20))
 ```
 """

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -1,0 +1,160 @@
+# Position-Specific Scoring Matrix (PSSM)
+# =======================================
+
+"""
+    struct PSSMResult{T,A}
+        scores::Matrix{T}
+        alphabet::A
+        background::Vector{Float64}
+        base::Float64
+    end
+
+Result returned by [`pssm`](@ref), containing the log-odds scores for a protein PSSM.
+`scores` is a matrix whose rows follow the provided `alphabet` ordering and whose columns
+match the alignment positions.
+"""
+struct PSSMResult{T,A}
+    scores::Matrix{T}
+    alphabet::A
+    background::Vector{Float64}
+    base::Float64
+end
+
+@inline function _collect_background(background, alphabet::ResidueAlphabet)
+    values =
+        if background isa Probabilities || background isa ContingencyTable
+            gettablearray(background)
+        else
+            background
+        end
+    vector = Float64.(vec(values))
+    length(vector) == length(alphabet) ||
+        throw(ArgumentError("Background length $(length(vector)) doesn't match alphabet length $(length(alphabet))."))
+    total = sum(vector)
+    total > 0 || throw(ArgumentError("Background distribution sums to zero."))
+    if total != 1
+        vector ./= total
+    end
+    vector
+end
+
+@inline function _log_odds(
+    p::Float64,
+    q::Float64,
+    zero_policy::Symbol,
+    use_log2::Bool,
+    invlogbase::Float64,
+    epsT::Float64,
+)
+    if zero_policy === :clamp
+        p = max(p, epsT)
+        q = max(q, epsT)
+    elseif zero_policy === :error
+        (p > 0 && q > 0) || throw(DomainError((p, q), "Zero probability encountered."))
+    else
+        # zero_policy === :negInf
+        if p == 0 && q == 0
+            return NaN
+        elseif p == 0
+            return -Inf
+        elseif q == 0
+            return Inf
+        end
+    end
+    ratio = p / q
+    use_log2 ? log2(ratio) : log(ratio) * invlogbase
+end
+
+"""
+    pssm(msa::AbstractArray{Residue}; kwargs...) -> PSSMResult
+
+Compute a log-odds position-specific scoring matrix (PSSM) from a protein MSA using
+MIToS probability estimation. Scores are returned as a matrix with rows ordered by the
+provided alphabet and columns corresponding to alignment positions.
+
+# Keywords
+- `dims::Int = 2`: compute scores per column. Other values throw an `ArgumentError`.
+- `alphabet = UngappedAlphabet()`: residue alphabet; score rows follow this order.
+- `weights = NoClustering()`: sequence weights used during probability estimation.
+- `pseudocounts = NoPseudocount()`: pseudocounts applied before normalization.
+- `background = BLOSUM62_Pi`: background distribution `q(a)`; accepts vectors,
+  `Probabilities` or `ContingencyTable` objects. It is normalized if needed.
+- `base::Number = 2`: logarithm base (e.g., 2 for bits).
+- `gap_handling::Symbol = :skip`: if `:skip`, gaps are ignored when the alphabet includes
+  them; if `:include`, gaps are scored using their observed frequency.
+- `zero_policy::Symbol = :negInf`: handling of zero probabilities. `:negInf` produces
+  `-Inf`, `Inf` or `NaN`; `:error` throws; `:clamp` replaces zeros with `eps`.
+- `all_gap_value = NaN`: value used for every residue in columns with no valid
+  observations after applying the gap policy.
+
+# Examples
+```julia
+using MIToS.Information, MIToS.MSA
+
+msa = hcat(res"AC", res"AD", res"AE")' # three sequences, two positions
+result = pssm(msa; background = fill(1 / 20, 20))
+```
+"""
+function pssm(
+    msa::AbstractArray{Residue};
+    dims::Int = 2,
+    alphabet::ResidueAlphabet = UngappedAlphabet(),
+    weights::WeightTypes = NoClustering(),
+    pseudocounts::Pseudocount = NoPseudocount(),
+    background = BLOSUM62_Pi,
+    base::Number = 2,
+    gap_handling::Symbol = :skip,
+    zero_policy::Symbol = :negInf,
+    all_gap_value = NaN,
+)
+    dims == 2 || throw(ArgumentError("pssm supports dims=2 (per-column) only."))
+    gap_handling in (:skip, :include) ||
+        throw(ArgumentError("Unsupported gap_handling = $(gap_handling)."))
+    zero_policy in (:negInf, :error, :clamp) ||
+        throw(ArgumentError("Unsupported zero_policy = $(zero_policy)."))
+    base_val = Float64(base)
+    (base_val > 0) && (base_val != 1) ||
+        throw(ArgumentError("Base must be positive and different from 1."))
+
+    q = _collect_background(background, alphabet)
+
+    nres = length(alphabet)
+    ncols = size(msa, 2)
+    scores = Matrix{Float64}(undef, nres, ncols)
+
+    column_table = ContingencyTable(Float64, Val{1}, alphabet)
+    gap_index = alphabet[GAP]
+    include_gap = gap_handling === :include || gap_index > nres
+    use_log2 = base_val == 2
+    invlogbase = use_log2 ? 1.0 : inv(log(base_val))
+    epsT = eps(Float64)
+
+    freq_array = gettablearray(column_table)
+
+    @inbounds for j = 1:ncols
+        cleanup!(column_table)
+        col_view = @view msa[:, j]
+        frequencies!(column_table, col_view; weights = weights, pseudocounts = pseudocounts)
+
+        if !include_gap && gap_index <= nres
+            freq_array[gap_index] = 0.0
+            update_marginals!(column_table)
+        end
+
+        total = gettotal(column_table)
+        if total == 0
+            scores[:, j] .= all_gap_value
+            continue
+        end
+
+        normalize!(column_table)
+        prob_view = gettablearray(column_table)
+        for i = 1:nres
+            p = prob_view[i]
+            qi = q[i]
+            scores[i, j] = _log_odds(p, qi, zero_policy, use_log2, invlogbase, epsT)
+        end
+    end
+
+    PSSMResult(scores, alphabet, q, base_val)
+end

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -12,6 +12,7 @@ profiles are matrix-like with shape (n_residues × n_positions), where rows foll
 chosen residue alphabet and columns correspond to alignment positions.
 
 Concrete subtypes represent three stages of a profile:
+
   - PFM ([`PositionFrequencyMatrix`](@ref)): ``fᵢ(a)`` is the (possibly weighted and
     pseudocounted) count of residue a in column i.
   - PSPM ([`PositionSpecificProbabilityMatrix`](@ref)): ``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``,
@@ -35,11 +36,11 @@ abstract type AbstractPositionSpecificMatrix{A} <: AbstractArray{Float64,2} end
     end
 
 Position frequency matrix (PFM) for a protein MSA representing the frequencies/counts of
-each residue at each alignment position. So that ``fᵢ(a)`` is the (possibly weighted and 
-pseudocounted) count of residue a in column i. Weights can down-weight redundant sequences, 
-and pseudocounts smooth columns with sparse observations. 
-A `PositionFrequencyMatrix` is a subtype of [`AbstractPositionSpecificMatrix`](@ref). That 
-stores the frequency matrix in the `table` field. `table` is a `NamedArray` whose rows 
+each residue at each alignment position. So that ``fᵢ(a)`` is the (possibly weighted and
+pseudocounted) count of residue a in column i. Weights can down-weight redundant sequences,
+and pseudocounts smooth columns with sparse observations.
+A `PositionFrequencyMatrix` is a subtype of [`AbstractPositionSpecificMatrix`](@ref). That
+stores the frequency matrix in the `table` field. `table` is a `NamedArray` whose rows
 follow the provided `alphabet` ordering and whose columns correspond to alignment positions.
 """
 struct PositionFrequencyMatrix{A} <: AbstractPositionSpecificMatrix{A}
@@ -90,7 +91,7 @@ columns match the alignment positions.
 struct PositionSpecificScoreMatrix{A} <: AbstractPositionSpecificMatrix{A}
     table::NamedArray{Float64,2,Array{Float64,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
-    base::Union{Irrational{:ℯ}, Float64, Int}
+    base::Union{Irrational{:ℯ},Float64,Int}
 end
 
 # Getters
@@ -111,15 +112,11 @@ end
 # Show
 # ----
 
-function Base.show(
-    io::IO,
-    ::MIME"text/plain",
-    scores::PositionSpecificScoreMatrix,
-)
+function Base.show(io::IO, ::MIME"text/plain", scores::PositionSpecificScoreMatrix)
     base_val = scores.base
     unit =
-        base_val == ℯ ? "nats" : base_val == 2 ? "bits" : base_val == 10 ? "hartleys" :
-        nothing
+        base_val == ℯ ? "nats" :
+        base_val == 2 ? "bits" : base_val == 10 ? "hartleys" : nothing
     print(io, typeof(scores), " log base=", base_val)
     if unit !== nothing
         print(io, " units=", unit)
@@ -225,9 +222,9 @@ end
 Compute a position frequency matrix (PFM) from a protein MSA. Each column summarizes how
 often each residue appears at that alignment position. Therefore, for column i and residue
 a, ``fᵢ(a)`` is the (possibly weighted and pseudocounted) count of that residue in that
-column. The `weights` reduce redundancy in highly similar MSAs (so closely related 
-sequences do not dominate), and `pseudocounts` smooth sparse columns to avoid zero 
-frequencies. The chosen `alphabet` defines which symbols are counted; for example, an 
+column. The `weights` reduce redundancy in highly similar MSAs (so closely related
+sequences do not dominate), and `pseudocounts` smooth sparse columns to avoid zero
+frequencies. The chosen `alphabet` defines which symbols are counted; for example, an
 ungapped alphabet ignores gaps while a gapped alphabet treats the gap as a symbol.
 
 # Keyword Arguments
@@ -238,7 +235,7 @@ ungapped alphabet ignores gaps while a gapped alphabet treats the gap as a symbo
 
 # Returns
 
-[`PositionFrequencyMatrix`](@ref) with rows in alphabet order and columns matching 
+[`PositionFrequencyMatrix`](@ref) with rows in alphabet order and columns matching
 alignment positions.
 """
 function position_frequency_matrix(
@@ -276,9 +273,9 @@ end
     position_specific_probability_matrix(pfm::PositionFrequencyMatrix)
     position_specific_probability_matrix(msa::AbstractArray{Residue}; kwargs...)
 
-Build a position-specific probability matrix (PSPM). Internally, it converts a PFM 
-(position frequency matrix) into a PSPM by column-wise normalization using 
-``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment column, a is a residue symbol in 
+Build a position-specific probability matrix (PSPM). Internally, it converts a PFM
+(position frequency matrix) into a PSPM by column-wise normalization using
+``pᵢ(a) = fᵢ(a) / ∑ₐ fᵢ(a)``, where i is the alignment column, a is a residue symbol in
 the alphabet, and ``∑ₐ`` sums over all residues in that alphabet. When built from an MSA,
 the PFM is computed first using the provided keyword arguments.
 
@@ -335,7 +332,7 @@ position frequency matrix (PFM), or a position-specific probability matrix (PSPM
 Positive scores indicate enrichment over background; negative scores indicate depletion.
 PSSMs are used to score sequences against a profile.
 
-# Keywords
+# Keyword Arguments
 
   - `alphabet = UngappedAlphabet()`: residue alphabet; score rows follow this order.
   - `weights = NoClustering()`: sequence weights used during probability estimation.
@@ -358,6 +355,11 @@ observations (e.g. all gaps using `UngappedAlphabet()`) are filled with `NaN`.
 
 The base controls units: b = 2 yields bits, b = ℯ yields nats, and b = 10 yields
 hartleys.
+
+# Results
+
+[`PositionSpecificScoreMatrix`](@ref) with rows in alphabet order and columns matching
+alignment positions.
 
 # Examples
 
@@ -410,8 +412,7 @@ function position_specific_scoring_matrix(
             p = @inbounds X[i, j]
             qi = @inbounds q[i]
             ratio = p / qi
-            @inbounds X[i, j] =
-                invlogbase == 1.0 ? log(ratio) : log(ratio) * invlogbase
+            @inbounds X[i, j] = invlogbase == 1.0 ? log(ratio) : log(ratio) * invlogbase
         end
     end
 

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -109,6 +109,13 @@ for f in (:size, :getindex)
         $(f)(gettable(scores), args...)
 end
 
+@inline function Base.getindex(scores::AbstractPositionSpecificMatrix, r::Residue, c::Int)
+    i = scores.alphabet[r]
+    table = gettablearray(scores)
+    @boundscheck checkbounds(table, i, c)
+    @inbounds table[i, c]
+end
+
 # Show
 # ----
 

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -13,7 +13,6 @@ abstract type AbstractColumnScores{T,N,A} <: AbstractArray{T,N} end
     struct PositionSpecificScoreMatrix{T,A}
         table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
         alphabet::A
-        background::Vector{Float64}
         base::Union{Irrational{:ℯ}, Float64, Int}
     end
 
@@ -24,7 +23,6 @@ match the alignment positions.
 struct PositionSpecificScoreMatrix{T,A} <: AbstractColumnScores{T,2,A}
     table::NamedArray{T,2,Array{T,2},NTuple{2,OrderedDict{String,Int}}}
     alphabet::A
-    background::Vector{Float64}
     base::Union{Irrational{:ℯ}, Float64, Int}
 end
 
@@ -47,7 +45,15 @@ end
 # ----
 
 function Base.show(io::IO, ::MIME"text/plain", scores::AbstractColumnScores)
-    print(io, typeof(scores), " : ")
+    base_val = scores.base
+    unit =
+        base_val == ℯ ? "nats" : base_val == 2 ? "bits" : base_val == 10 ? "hartleys" :
+        nothing
+    print(io, typeof(scores), " log base=", base_val)
+    if unit !== nothing
+        print(io, " units=", unit)
+    end
+    print(io, " : ")
     print(io, "\ntable : ")
     show(io, MIME"text/plain"(), gettable(scores))
 end
@@ -149,11 +155,10 @@ function position_specific_scoring_matrix(
     background = BLOSUM62_Pi,
     base::Number = ℯ,
 )
-    base_val = _convert_base(base)
-    if !(base_val > 0) || base_val == 1 # this also catches NaN
+    if !(base > 0) || base == 1 # this also catches NaN
         throw(
             ArgumentError(
-                "The logarithm base must be positive and different from 1 (base=$base_val).",
+                "The logarithm base must be positive and different from 1 (base=$base).",
             ),
         )
     end
@@ -165,7 +170,7 @@ function position_specific_scoring_matrix(
     scores = Matrix{Float64}(undef, nres, ncols)
 
     column_table = ContingencyTable(Float64, Val{1}, alphabet)
-    invlogbase = base_val === ℯ ? 1.0 : inv(log(base_val))
+    invlogbase = base === ℯ ? 1.0 : inv(log(base))
 
     for j = 1:ncols
         cleanup!(column_table)
@@ -188,7 +193,7 @@ function position_specific_scoring_matrix(
     row_dict = getnamedict(alphabet)
     col_names = columnnames(msa)
     col_dict = OrderedDict{String,Int}(col_names[i] => i for i = 1:ncols)
-    table = NamedArray(scores, (row_dict, col_dict), ("Residue", "Col"))
+    table = NamedArray(scores, (row_dict, col_dict), ("Res", "Col"))
 
-    PositionSpecificScoreMatrix(table, alphabet, q, base_val)
+    PositionSpecificScoreMatrix(table, alphabet, _convert_base(base))
 end

--- a/src/Information/PSSM.jl
+++ b/src/Information/PSSM.jl
@@ -6,7 +6,7 @@
         scores::Matrix{T}
         alphabet::A
         background::Vector{Float64}
-        base::Float64
+        base::Union{Irrational{:ℯ}, Float64, Int}
     end
 
 Result returned by [`position_specific_scoring_matrix`](@ref), containing the log-odds scores for a protein PSSM.
@@ -17,7 +17,15 @@ struct PSSMResult{T,A}
     scores::Matrix{T}
     alphabet::A
     background::Vector{Float64}
-    base::Float64
+    base::Union{Irrational{:ℯ},Float64,Int}
+end
+
+# helpers to mostly use Float64 for bases, but keeping ℯ and 2 as is
+@inline _convert_base(base::Irrational{:ℯ}) = base
+@inline _convert_base(base::Int) = base
+@inline _convert_base(base::Number) = Float64(base)
+@inline function _convert_base(base::Integer) # promote to Int if possible
+    base <= typemax(Int) ? Int(base) : Float64(base) # base should be positive
 end
 
 function _collect_background(background::AbstractArray, alphabet::ResidueAlphabet)
@@ -96,10 +104,11 @@ function position_specific_scoring_matrix(
     background = BLOSUM62_Pi,
     base::Number = ℯ,
 )
-    if !(base > 0) || base == 1 # this also catches NaN
+    base_val = _convert_base(base)
+    if !(base_val > 0) || base_val == 1 # this also catches NaN
         throw(
             ArgumentError(
-                "The logarithm base must be positive and different from 1 (base=$base).",
+                "The logarithm base must be positive and different from 1 (base=$base_val).",
             ),
         )
     end
@@ -111,7 +120,7 @@ function position_specific_scoring_matrix(
     scores = Matrix{Float64}(undef, nres, ncols)
 
     column_table = ContingencyTable(Float64, Val{1}, alphabet)
-    invlogbase = base === ℯ ? 1.0 : inv(log(base))
+    invlogbase = base_val === ℯ ? 1.0 : inv(log(base_val))
 
     for j = 1:ncols
         cleanup!(column_table)
@@ -130,5 +139,5 @@ function position_specific_scoring_matrix(
         end
     end
 
-    PSSMResult(scores, alphabet, q, Float64(base))
+    PSSMResult(scores, alphabet, q, base_val)
 end

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -3,6 +3,21 @@
     alphabet = UngappedAlphabet()
     uniform_background = fill(1 / 20, 20)
 
+    function _approx_with_nan(a, b; atol = 0.0, rtol = 0.0)
+        size(a) == size(b) || return false
+        for i in eachindex(a, b)
+            ai = a[i]
+            bi = b[i]
+            if isnan(ai) && isnan(bi)
+                continue
+            end
+            if !isapprox(ai, bi; atol = atol, rtol = rtol)
+                return false
+            end
+        end
+        return true
+    end
+
     @testset "Shape and ordering" begin
         msa = Residue[
             'A' 'E'
@@ -18,6 +33,100 @@
 
         @test size(result.table) == (length(alphabet), size(msa, 2))
         @test result.alphabet == alphabet
+    end
+
+    @testset "Frequencies" begin
+        msa = Residue[
+            'A' 'C'
+            'A' GAP
+            'C' 'C'
+        ]
+
+        pfm = position_frequency_matrix(msa; alphabet = alphabet)
+
+        a_index = alphabet[Residue('A')]
+        c_index = alphabet[Residue('C')]
+
+        @test pfm.table[a_index, 1] == 2
+        @test pfm.table[c_index, 1] == 1
+        @test pfm.table[c_index, 2] == 2
+        @test pfm.table[a_index, 2] == 0
+
+        gapped = GappedAlphabet()
+        gpfm = position_frequency_matrix(msa; alphabet = gapped)
+        gap_index = gapped[GAP]
+
+        @test gpfm.table[gap_index, 2] == 1
+    end
+
+    @testset "Probabilities" begin
+        msa = Residue[
+            'A' 'C'
+            'A' GAP
+            'C' 'C'
+        ]
+
+        ppm = position_specific_probability_matrix(msa; alphabet = alphabet)
+
+        @test isapprox(sum(ppm.table[:, 1]), 1.0)
+        @test isapprox(sum(ppm.table[:, 2]), 1.0)
+
+        msa_gap = fill(GAP, 3, 1)
+        ppm_gap = position_specific_probability_matrix(msa_gap; alphabet = alphabet)
+        @test all(isnan, ppm_gap.table[:, 1])
+
+        ppm_from_freqs = position_specific_probability_matrix(
+            position_frequency_matrix(msa; alphabet = alphabet),
+        )
+
+        @test _approx_with_nan(
+            gettablearray(ppm),
+            gettablearray(ppm_from_freqs),
+        )
+    end
+
+    @testset "Scoring overloads and non-mutating semantics" begin
+        msa = reshape(Residue['A', 'A', 'C'], 3, 1)
+
+        pssm_msa = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+            base = 2,
+        )
+        pssm_freqs = position_specific_scoring_matrix(
+            position_frequency_matrix(msa; alphabet = alphabet);
+            background = uniform_background,
+            base = 2,
+        )
+        pssm_probs = position_specific_scoring_matrix(
+            position_specific_probability_matrix(msa; alphabet = alphabet);
+            background = uniform_background,
+            base = 2,
+        )
+
+        @test _approx_with_nan(
+            gettablearray(pssm_msa),
+            gettablearray(pssm_freqs),
+        )
+        @test _approx_with_nan(
+            gettablearray(pssm_msa),
+            gettablearray(pssm_probs),
+        )
+
+        pfm0 = position_frequency_matrix(msa; alphabet = alphabet)
+        pfm1 = deepcopy(pfm0)
+        position_specific_probability_matrix(pfm0)
+        @test gettablearray(pfm0) == gettablearray(pfm1)
+
+        ppm0 = position_specific_probability_matrix(msa; alphabet = alphabet)
+        ppm1 = deepcopy(ppm0)
+        position_specific_scoring_matrix(
+            ppm0;
+            background = uniform_background,
+            base = 2,
+        )
+        @test gettablearray(ppm0) == gettablearray(ppm1)
     end
 
     @testset "Log-odds correctness" begin

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -18,7 +18,6 @@
 
         @test size(result.table) == (length(alphabet), size(msa, 2))
         @test result.alphabet == alphabet
-        @test result.background ≈ uniform_background
     end
 
     @testset "Log-odds correctness" begin

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -1,22 +1,7 @@
 @testset "PSSM" begin
 
     alphabet = UngappedAlphabet()
-    uniform_background = fill(1 / 20, 20)
-
-    function _approx_with_nan(a, b; atol = 0.0, rtol = 0.0)
-        size(a) == size(b) || return false
-        for i in eachindex(a, b)
-            ai = a[i]
-            bi = b[i]
-            if isnan(ai) && isnan(bi)
-                continue
-            end
-            if !isapprox(ai, bi; atol = atol, rtol = rtol)
-                return false
-            end
-        end
-        return true
-    end
+    uniform_background = fill(1 / 20, 20) # uniform distribution for the UngappedAlphabet
 
     @testset "Shape and ordering" begin
         msa = Residue[
@@ -32,6 +17,7 @@
         )
 
         @test size(result.table) == (length(alphabet), size(msa, 2))
+        @test length(result) == length(alphabet) * size(msa, 2)
         @test result.alphabet == alphabet
     end
 
@@ -79,10 +65,7 @@
             position_frequency_matrix(msa; alphabet = alphabet),
         )
 
-        @test _approx_with_nan(
-            gettablearray(ppm),
-            gettablearray(ppm_from_freqs),
-        )
+        @test isapprox(gettablearray(ppm), gettablearray(ppm_from_freqs); nans = true)
     end
 
     @testset "Scoring overloads and non-mutating semantics" begin
@@ -105,14 +88,8 @@
             base = 2,
         )
 
-        @test _approx_with_nan(
-            gettablearray(pssm_msa),
-            gettablearray(pssm_freqs),
-        )
-        @test _approx_with_nan(
-            gettablearray(pssm_msa),
-            gettablearray(pssm_probs),
-        )
+        @test isapprox(gettablearray(pssm_msa), gettablearray(pssm_freqs); nans = true)
+        @test isapprox(gettablearray(pssm_msa), gettablearray(pssm_probs); nans = true)
 
         pfm0 = position_frequency_matrix(msa; alphabet = alphabet)
         pfm1 = deepcopy(pfm0)
@@ -121,11 +98,7 @@
 
         ppm0 = position_specific_probability_matrix(msa; alphabet = alphabet)
         ppm1 = deepcopy(ppm0)
-        position_specific_scoring_matrix(
-            ppm0;
-            background = uniform_background,
-            base = 2,
-        )
+        position_specific_scoring_matrix(ppm0; background = uniform_background, base = 2)
         @test gettablearray(ppm0) == gettablearray(ppm1)
     end
 

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -4,11 +4,17 @@
     uniform_background = fill(1 / 20, 20)
 
     @testset "Shape and ordering" begin
-        msa = Matrix{Residue}(undef, 3, 2)
-        msa[:, 1] = Residue[Residue('A'), Residue('C'), Residue('D')]
-        msa[:, 2] = Residue[Residue('E'), Residue('F'), Residue('G')]
+        msa = Residue[
+            'A' 'E'
+            'C' 'F'
+            'D' 'G'
+        ]
 
-        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+        )
 
         @test size(result.scores) == (length(alphabet), size(msa, 2))
         @test result.alphabet == alphabet
@@ -16,10 +22,14 @@
     end
 
     @testset "Log-odds correctness" begin
-        msa = Matrix{Residue}(undef, 3, 1)
-        msa[:, 1] = Residue[Residue('A'), Residue('A'), Residue('C')]
+        msa = reshape(Residue['A', 'A', 'C'], 3, 1)
 
-        result = pssm(msa; alphabet = alphabet, background = uniform_background, base = 2)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+            base = 2,
+        )
 
         p_a = 2 / 3
         p_c = 1 / 3
@@ -31,15 +41,18 @@
     end
 
     @testset "Alphabet controls gap counting" begin
-        msa = Matrix{Residue}(undef, 3, 1)
-        msa[:, 1] = Residue[Residue('A'), GAP, GAP]
+        msa = reshape(Residue['A', GAP, GAP], 3, 1)
 
-        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+        )
 
         a_index = alphabet[Residue('A')]
         c_index = alphabet[Residue('C')]
 
-        @test isapprox(result.scores[a_index, 1], log2(1.0 / uniform_background[a_index]))
+        @test isapprox(result.scores[a_index, 1], log(1.0 / uniform_background[a_index]))
         @test result.scores[c_index, 1] == -Inf
     end
 
@@ -48,23 +61,30 @@
         uniform_21 = fill(1 / length(gapped), length(gapped))
         msa = fill(GAP, 3, 1)
 
-        result = pssm(msa; alphabet = gapped, background = uniform_21)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = gapped,
+            background = uniform_21,
+        )
 
         gap_index = gapped[GAP]
         a_index = gapped[Residue('A')]
         q_gap = uniform_21[gap_index]
 
         @test isfinite(result.scores[gap_index, 1])
-        @test isapprox(result.scores[gap_index, 1], log2(1.0 / q_gap))
+        @test isapprox(result.scores[gap_index, 1], log(1.0 / q_gap))
         @test result.scores[a_index, 1] == -Inf
     end
 
     @testset "Zero probabilities" begin
-        msa = Matrix{Residue}(undef, 2, 1)
-        msa[:, 1] = Residue[Residue('A'), Residue('A')]
+        msa = reshape(Residue['A', 'A'], 2, 1)
 
         c_index = alphabet[Residue('C')]
-        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+        )
         @test isinf(result.scores[c_index, 1]) && result.scores[c_index, 1] < 0
     end
 
@@ -75,28 +95,51 @@
         q ./= sum(q)
 
         msa_a = fill(Residue('A'), 2, 1)
-        result_inf = pssm(msa_a; alphabet = alphabet, background = q)
+        result_inf =
+            position_specific_scoring_matrix(msa_a; alphabet = alphabet, background = q)
         @test isinf(result_inf.scores[a_index, 1]) && result_inf.scores[a_index, 1] > 0
 
         msa_c = fill(Residue('C'), 2, 1)
-        result_nan = pssm(msa_c; alphabet = alphabet, background = q)
+        result_nan =
+            position_specific_scoring_matrix(msa_c; alphabet = alphabet, background = q)
         @test isnan(result_nan.scores[a_index, 1])
     end
 
     @testset "Non-default base" begin
-        msa = Matrix{Residue}(undef, 3, 1)
-        msa[:, 1] = Residue[Residue('A'), Residue('A'), Residue('C')]
+        msa = reshape(Residue['A', 'A', 'C'], 3, 1)
 
-        result = pssm(msa; alphabet = alphabet, background = uniform_background, base = 10)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+            base = 10,
+        )
 
         p_a = 2 / 3
         q_a = uniform_background[alphabet[Residue('A')]]
         @test isapprox(result.scores[alphabet[Residue('A')], 1], log10(p_a / q_a))
     end
 
+    @testset "Invalid base" begin
+        msa = reshape(Residue['A'], 1, 1)
+
+        for base in [-1.0, 0.0, 1.0]
+            @test_throws ArgumentError position_specific_scoring_matrix(
+                msa;
+                alphabet = alphabet,
+                background = uniform_background,
+                base = base,
+            )
+        end
+    end
+
     @testset "All-gap column" begin
         msa = fill(GAP, 3, 1)
-        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+        result = position_specific_scoring_matrix(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+        )
         @test all(isnan, result.scores[:, 1])
     end
 
@@ -105,7 +148,7 @@
 
         @testset "Length mismatch" begin
             background = fill(1 / 19, 19)
-            @test_throws ArgumentError pssm(
+            @test_throws ArgumentError position_specific_scoring_matrix(
                 msa;
                 alphabet = alphabet,
                 background = background,
@@ -114,19 +157,31 @@
 
         @testset "Zero sum" begin
             background = zeros(20)
-            @test_throws DomainError pssm(msa; alphabet = alphabet, background = background)
+            @test_throws DomainError position_specific_scoring_matrix(
+                msa;
+                alphabet = alphabet,
+                background = background,
+            )
         end
 
         @testset "Non-finite" begin
             background = fill(1 / 20, 20)
             background[1] = NaN
-            @test_throws DomainError pssm(msa; alphabet = alphabet, background = background)
+            @test_throws DomainError position_specific_scoring_matrix(
+                msa;
+                alphabet = alphabet,
+                background = background,
+            )
         end
 
         @testset "Negative" begin
             background = fill(1 / 20, 20)
             background[1] = -0.1
-            @test_throws DomainError pssm(msa; alphabet = alphabet, background = background)
+            @test_throws DomainError position_specific_scoring_matrix(
+                msa;
+                alphabet = alphabet,
+                background = background,
+            )
         end
     end
 end

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -30,37 +30,74 @@
         @test isapprox(result.scores[alphabet[Residue('C')], 1], log2(p_c / q_c))
     end
 
-    @testset "Zero policies" begin
+    @testset "Alphabet controls gap counting" begin
+        msa = Matrix{Residue}(undef, 3, 1)
+        msa[:, 1] = Residue[Residue('A'), GAP, GAP]
+
+        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+
+        a_index = alphabet[Residue('A')]
+        c_index = alphabet[Residue('C')]
+
+        @test isapprox(result.scores[a_index, 1], log2(1.0 / uniform_background[a_index]))
+        @test result.scores[c_index, 1] == -Inf
+    end
+
+    @testset "GappedAlphabet counts gaps" begin
+        gapped = GappedAlphabet()
+        uniform_21 = fill(1 / length(gapped), length(gapped))
+        msa = fill(GAP, 3, 1)
+
+        result = pssm(msa; alphabet = gapped, background = uniform_21)
+
+        gap_index = gapped[GAP]
+        a_index = gapped[Residue('A')]
+        q_gap = uniform_21[gap_index]
+
+        @test isfinite(result.scores[gap_index, 1])
+        @test isapprox(result.scores[gap_index, 1], log2(1.0 / q_gap))
+        @test result.scores[a_index, 1] == -Inf
+    end
+
+    @testset "Zero probabilities" begin
         msa = Matrix{Residue}(undef, 2, 1)
         msa[:, 1] = Residue[Residue('A'), Residue('A')]
 
-        neg_inf = pssm(msa; alphabet = alphabet, background = uniform_background, zero_policy = :negInf)
-        clamp = pssm(msa; alphabet = alphabet, background = uniform_background, zero_policy = :clamp)
-
         c_index = alphabet[Residue('C')]
-        @test isinf(neg_inf.scores[c_index, 1]) && neg_inf.scores[c_index, 1] < 0
+        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+        @test isinf(result.scores[c_index, 1]) && result.scores[c_index, 1] < 0
+    end
 
-        expected_clamp = log2(eps(Float64) / uniform_background[c_index])
-        @test isapprox(clamp.scores[c_index, 1], expected_clamp)
+    @testset "Zero background entries" begin
+        q = copy(uniform_background)
+        a_index = alphabet[Residue('A')]
+        q[a_index] = 0.0
+        q ./= sum(q)
 
-        @test_throws DomainError pssm(
-            msa;
-            alphabet = alphabet,
-            background = uniform_background,
-            zero_policy = :error,
-        )
+        msa_a = fill(Residue('A'), 2, 1)
+        result_inf = pssm(msa_a; alphabet = alphabet, background = q)
+        @test isinf(result_inf.scores[a_index, 1]) && result_inf.scores[a_index, 1] > 0
+
+        msa_c = fill(Residue('C'), 2, 1)
+        result_nan = pssm(msa_c; alphabet = alphabet, background = q)
+        @test isnan(result_nan.scores[a_index, 1])
+    end
+
+    @testset "Non-default base" begin
+        msa = Matrix{Residue}(undef, 3, 1)
+        msa[:, 1] = Residue[Residue('A'), Residue('A'), Residue('C')]
+
+        result = pssm(msa; alphabet = alphabet, background = uniform_background, base = 10)
+
+        p_a = 2 / 3
+        q_a = uniform_background[alphabet[Residue('A')]]
+        @test isapprox(result.scores[alphabet[Residue('A')], 1], log10(p_a / q_a))
     end
 
     @testset "All-gap column" begin
         msa = fill(GAP, 3, 1)
-        result = pssm(
-            msa;
-            alphabet = alphabet,
-            background = uniform_background,
-            all_gap_value = 123.0,
-        )
-
-        @test all(result.scores[:, 1] .== 123.0)
+        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+        @test all(isnan, result.scores[:, 1])
     end
 
     @testset "dims validation" begin

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -100,17 +100,16 @@
         @test all(isnan, result.scores[:, 1])
     end
 
-    @testset "dims validation" begin
-        msa = reshape(res"AC", 1, :)
-        @test_throws ArgumentError pssm(msa; dims = 1)
-    end
-
     @testset "Background validation" begin
         msa = permutedims(hcat(res"AC", res"AD")) # 2 sequences, 2 columns
 
         @testset "Length mismatch" begin
             background = fill(1 / 19, 19)
-            @test_throws ArgumentError pssm(msa; alphabet = alphabet, background = background)
+            @test_throws ArgumentError pssm(
+                msa;
+                alphabet = alphabet,
+                background = background,
+            )
         end
 
         @testset "Zero sum" begin

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -3,7 +3,7 @@
     alphabet = UngappedAlphabet()
     uniform_background = fill(1 / 20, 20) # uniform distribution for the UngappedAlphabet
 
-    @testset "Shape and ordering" begin
+    @testset "Shape, ordering and values" begin
         msa = Residue[
             'A' 'E'
             'C' 'F'
@@ -19,6 +19,8 @@
         @test size(result.table) == (length(alphabet), size(msa, 2))
         @test length(result) == length(alphabet) * size(msa, 2)
         @test result.alphabet == alphabet
+        @test eltype(result) === Float64
+        @test sum(isfinite.(result), dims = 1) == [3 3] # 3 different residues per column
     end
 
     @testset "Frequencies" begin
@@ -30,19 +32,22 @@
 
         pfm = position_frequency_matrix(msa; alphabet = alphabet)
 
-        a_index = alphabet[Residue('A')]
-        c_index = alphabet[Residue('C')]
+        a_index = alphabet[Residue('A')] # 1
+        c_index = alphabet[Residue('C')] # 5
 
         @test pfm.table[a_index, 1] == 2
         @test pfm.table[c_index, 1] == 1
         @test pfm.table[c_index, 2] == 2
         @test pfm.table[a_index, 2] == 0
+        @test sum(pfm, dims = 1) == [3 2] # gaps not counted
 
         gapped = GappedAlphabet()
         gpfm = position_frequency_matrix(msa; alphabet = gapped)
-        gap_index = gapped[GAP]
+        gap_index = gapped[GAP] # 21
 
+        @test gpfm.table[gap_index, 1] == 0
         @test gpfm.table[gap_index, 2] == 1
+        @test sum(gpfm, dims = 1) == [3 3] # gaps counted
     end
 
     @testset "Probabilities" begin
@@ -54,18 +59,19 @@
 
         ppm = position_specific_probability_matrix(msa; alphabet = alphabet)
 
+        # P should sum to 1 per column
         @test isapprox(sum(ppm.table[:, 1]), 1.0)
         @test isapprox(sum(ppm.table[:, 2]), 1.0)
 
-        msa_gap = fill(GAP, 3, 1)
+        msa_gap = fill(GAP, 3, 1) # all-gap column
         ppm_gap = position_specific_probability_matrix(msa_gap; alphabet = alphabet)
         @test all(isnan, ppm_gap.table[:, 1])
 
+        # same result when computed from frequencies than directly from an MSA
         ppm_from_freqs = position_specific_probability_matrix(
             position_frequency_matrix(msa; alphabet = alphabet),
         )
-
-        @test isapprox(gettablearray(ppm), gettablearray(ppm_from_freqs); nans = true)
+        @test isapprox(gettablearray(ppm), gettablearray(ppm_from_freqs))
     end
 
     @testset "Scoring overloads and non-mutating semantics" begin
@@ -88,18 +94,24 @@
             base = 2,
         )
 
-        @test isapprox(gettablearray(pssm_msa), gettablearray(pssm_freqs); nans = true)
-        @test isapprox(gettablearray(pssm_msa), gettablearray(pssm_probs); nans = true)
+        @test isapprox(gettablearray(pssm_msa), gettablearray(pssm_freqs))
+        @test isapprox(gettablearray(pssm_msa), gettablearray(pssm_probs))
 
-        pfm0 = position_frequency_matrix(msa; alphabet = alphabet)
-        pfm1 = deepcopy(pfm0)
-        position_specific_probability_matrix(pfm0)
-        @test gettablearray(pfm0) == gettablearray(pfm1)
+        @testset "non-mutating behavior" begin
+            pfm_original = position_frequency_matrix(msa; alphabet = alphabet)
+            pfm_backup = deepcopy(pfm_original)
+            position_specific_probability_matrix(pfm_original)
+            @test gettablearray(pfm_original) == gettablearray(pfm_backup)
 
-        ppm0 = position_specific_probability_matrix(msa; alphabet = alphabet)
-        ppm1 = deepcopy(ppm0)
-        position_specific_scoring_matrix(ppm0; background = uniform_background, base = 2)
-        @test gettablearray(ppm0) == gettablearray(ppm1)
+            ppm_original = position_specific_probability_matrix(msa; alphabet = alphabet)
+            ppm_backup = deepcopy(ppm_original)
+            position_specific_scoring_matrix(
+                ppm_original;
+                background = uniform_background,
+                base = 2,
+            )
+            @test gettablearray(ppm_original) == gettablearray(ppm_backup)
+        end
     end
 
     @testset "Log-odds correctness" begin
@@ -114,11 +126,12 @@
 
         p_a = 2 / 3
         p_c = 1 / 3
-        q_a = uniform_background[alphabet[Residue('A')]]
-        q_c = uniform_background[alphabet[Residue('C')]]
+        q_a = 0.05 # uniform background for the UngappedAlphabet
+        q_c = 0.05
 
         @test isapprox(result.table[alphabet[Residue('A')], 1], log2(p_a / q_a))
         @test isapprox(result.table[alphabet[Residue('C')], 1], log2(p_c / q_c))
+        @test isinf(result.table["R", 1]) # arginine not present in column
     end
 
     @testset "Alphabet controls gap counting" begin
@@ -130,11 +143,13 @@
             background = uniform_background,
         )
 
-        a_index = alphabet[Residue('A')]
-        c_index = alphabet[Residue('C')]
-
-        @test isapprox(result.table[a_index, 1], log(1.0 / uniform_background[a_index]))
-        @test result.table[c_index, 1] == -Inf
+        # UngappedAlphabet, so gaps not counted
+        @test isapprox(result["A", 1], log(1.0 / 0.05)) # uniform background
+        @test result["C", 1] == -Inf
+        @test result[1, 1] == result["A", 1] # index access works the same
+        @test result[1, 1] == result[Residue('A'), 1] # Residue access works the same
+        @test_throws BoundsError result[21, 1] # there is no value for gaps
+        @test_throws BoundsError result[GAP, 1] # there is no value for gaps
     end
 
     @testset "GappedAlphabet counts gaps" begin

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -1,0 +1,70 @@
+@testset "PSSM" begin
+
+    alphabet = UngappedAlphabet()
+    uniform_background = fill(1 / 20, 20)
+
+    @testset "Shape and ordering" begin
+        msa = Matrix{Residue}(undef, 3, 2)
+        msa[:, 1] = Residue[Residue('A'), Residue('C'), Residue('D')]
+        msa[:, 2] = Residue[Residue('E'), Residue('F'), Residue('G')]
+
+        result = pssm(msa; alphabet = alphabet, background = uniform_background)
+
+        @test size(result.scores) == (length(alphabet), size(msa, 2))
+        @test result.alphabet == alphabet
+        @test result.background ≈ uniform_background
+    end
+
+    @testset "Log-odds correctness" begin
+        msa = Matrix{Residue}(undef, 3, 1)
+        msa[:, 1] = Residue[Residue('A'), Residue('A'), Residue('C')]
+
+        result = pssm(msa; alphabet = alphabet, background = uniform_background, base = 2)
+
+        p_a = 2 / 3
+        p_c = 1 / 3
+        q_a = uniform_background[alphabet[Residue('A')]]
+        q_c = uniform_background[alphabet[Residue('C')]]
+
+        @test isapprox(result.scores[alphabet[Residue('A')], 1], log2(p_a / q_a))
+        @test isapprox(result.scores[alphabet[Residue('C')], 1], log2(p_c / q_c))
+    end
+
+    @testset "Zero policies" begin
+        msa = Matrix{Residue}(undef, 2, 1)
+        msa[:, 1] = Residue[Residue('A'), Residue('A')]
+
+        neg_inf = pssm(msa; alphabet = alphabet, background = uniform_background, zero_policy = :negInf)
+        clamp = pssm(msa; alphabet = alphabet, background = uniform_background, zero_policy = :clamp)
+
+        c_index = alphabet[Residue('C')]
+        @test isinf(neg_inf.scores[c_index, 1]) && neg_inf.scores[c_index, 1] < 0
+
+        expected_clamp = log2(eps(Float64) / uniform_background[c_index])
+        @test isapprox(clamp.scores[c_index, 1], expected_clamp)
+
+        @test_throws DomainError pssm(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+            zero_policy = :error,
+        )
+    end
+
+    @testset "All-gap column" begin
+        msa = fill(GAP, 3, 1)
+        result = pssm(
+            msa;
+            alphabet = alphabet,
+            background = uniform_background,
+            all_gap_value = 123.0,
+        )
+
+        @test all(result.scores[:, 1] .== 123.0)
+    end
+
+    @testset "dims validation" begin
+        msa = reshape(res"AC", 1, :)
+        @test_throws ArgumentError pssm(msa; dims = 1)
+    end
+end

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -16,7 +16,7 @@
             background = uniform_background,
         )
 
-        @test size(result.scores) == (length(alphabet), size(msa, 2))
+        @test size(result.table) == (length(alphabet), size(msa, 2))
         @test result.alphabet == alphabet
         @test result.background ≈ uniform_background
     end
@@ -36,8 +36,8 @@
         q_a = uniform_background[alphabet[Residue('A')]]
         q_c = uniform_background[alphabet[Residue('C')]]
 
-        @test isapprox(result.scores[alphabet[Residue('A')], 1], log2(p_a / q_a))
-        @test isapprox(result.scores[alphabet[Residue('C')], 1], log2(p_c / q_c))
+        @test isapprox(result.table[alphabet[Residue('A')], 1], log2(p_a / q_a))
+        @test isapprox(result.table[alphabet[Residue('C')], 1], log2(p_c / q_c))
     end
 
     @testset "Alphabet controls gap counting" begin
@@ -52,8 +52,8 @@
         a_index = alphabet[Residue('A')]
         c_index = alphabet[Residue('C')]
 
-        @test isapprox(result.scores[a_index, 1], log(1.0 / uniform_background[a_index]))
-        @test result.scores[c_index, 1] == -Inf
+        @test isapprox(result.table[a_index, 1], log(1.0 / uniform_background[a_index]))
+        @test result.table[c_index, 1] == -Inf
     end
 
     @testset "GappedAlphabet counts gaps" begin
@@ -71,9 +71,9 @@
         a_index = gapped[Residue('A')]
         q_gap = uniform_21[gap_index]
 
-        @test isfinite(result.scores[gap_index, 1])
-        @test isapprox(result.scores[gap_index, 1], log(1.0 / q_gap))
-        @test result.scores[a_index, 1] == -Inf
+        @test isfinite(result.table[gap_index, 1])
+        @test isapprox(result.table[gap_index, 1], log(1.0 / q_gap))
+        @test result.table[a_index, 1] == -Inf
     end
 
     @testset "Zero probabilities" begin
@@ -85,7 +85,7 @@
             alphabet = alphabet,
             background = uniform_background,
         )
-        @test isinf(result.scores[c_index, 1]) && result.scores[c_index, 1] < 0
+        @test isinf(result.table[c_index, 1]) && result.table[c_index, 1] < 0
     end
 
     @testset "Zero background entries" begin
@@ -97,12 +97,12 @@
         msa_a = fill(Residue('A'), 2, 1)
         result_inf =
             position_specific_scoring_matrix(msa_a; alphabet = alphabet, background = q)
-        @test isinf(result_inf.scores[a_index, 1]) && result_inf.scores[a_index, 1] > 0
+        @test isinf(result_inf.table[a_index, 1]) && result_inf.table[a_index, 1] > 0
 
         msa_c = fill(Residue('C'), 2, 1)
         result_nan =
             position_specific_scoring_matrix(msa_c; alphabet = alphabet, background = q)
-        @test isnan(result_nan.scores[a_index, 1])
+        @test isnan(result_nan.table[a_index, 1])
     end
 
     @testset "Non-default base" begin
@@ -117,7 +117,7 @@
 
         p_a = 2 / 3
         q_a = uniform_background[alphabet[Residue('A')]]
-        @test isapprox(result.scores[alphabet[Residue('A')], 1], log10(p_a / q_a))
+        @test isapprox(result.table[alphabet[Residue('A')], 1], log10(p_a / q_a))
     end
 
     @testset "Invalid base" begin
@@ -140,7 +140,7 @@
             alphabet = alphabet,
             background = uniform_background,
         )
-        @test all(isnan, result.scores[:, 1])
+        @test all(isnan, result.table[:, 1])
     end
 
     @testset "Background validation" begin

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -3,6 +3,199 @@
     alphabet = UngappedAlphabet()
     uniform_background = fill(1 / 20, 20) # uniform distribution for the UngappedAlphabet
 
+    @testset "Manual construction / empty matrices" begin
+        pfm = PositionFrequencyMatrix(alphabet, 3)
+        ppm = PositionSpecificProbabilityMatrix(alphabet, 3)
+        pssm = PositionSpecificScoringMatrix(alphabet, 3, 2)
+
+        @test Base.ismutabletype(typeof(pfm))
+        @test Base.ismutabletype(typeof(ppm))
+        @test Base.ismutabletype(typeof(pssm))
+
+        @test all(==(0.0), pfm)
+        @test all(isnan, ppm)
+        @test all(==(0.0), pssm)
+        @test pssm.base == 2
+
+        pfm_zeros = zeros(PositionFrequencyMatrix, alphabet, 2)
+        pssm_zeros = zeros(PositionSpecificScoringMatrix, alphabet, 2, 10)
+
+        @test all(==(0.0), pfm_zeros)
+        @test all(==(0.0), pssm_zeros)
+        @test pssm_zeros.base == 10
+
+        pssm[Residue('A'), 1] = 1.23
+        @test pssm[Residue('A'), 1] == 1.23
+        @test pssm["A", 1] == 1.23
+
+        data = zeros(Float64, length(alphabet), 4)
+        pssm2 = PositionSpecificScoringMatrix(data, alphabet, 2)
+        pssm2[Residue('A'), 1] = 4.56
+        @test pssm2[Residue('A'), 1] == 4.56
+        @test gettablearray(pssm2)[alphabet[Residue('A')], 1] == 4.56
+
+        pfm_named = PositionFrequencyMatrix(pfm.table, alphabet)
+        @test pfm_named["A", 1] == pfm["A", 1]
+
+        ppm_named = PositionSpecificProbabilityMatrix(ppm.table, alphabet)
+        @test isnan(ppm_named["A", 1])
+
+        @test_throws ArgumentError PositionFrequencyMatrix(pfm.table, GappedAlphabet())
+
+        pfm_data = PositionFrequencyMatrix(zeros(Float64, length(alphabet), 2), alphabet)
+        @test all(==(0.0), pfm_data)
+
+        bad_data = zeros(Float64, length(alphabet) - 1, 2)
+        @test_throws ErrorException PositionFrequencyMatrix(bad_data, alphabet)
+
+        pssm_float = PositionSpecificScoringMatrix(alphabet, 2, 2.5)
+        @test pssm_float.base == 2.5
+        @test pssm_float.base isa Float64
+
+        pssm_int = PositionSpecificScoringMatrix(alphabet, 2, 2)
+        @test pssm_int.base === 2
+
+        pssm_nat = PositionSpecificScoringMatrix(alphabet, 2, ℯ)
+        @test pssm_nat.base === ℯ
+
+        for base in (-1.0, 0.0, 1.0, NaN)
+            @test_throws ArgumentError PositionSpecificScoringMatrix(alphabet, 2, base)
+        end
+    end
+
+    @testset "Score sequence" begin
+        pssm = PositionSpecificScoringMatrix(alphabet, 2)
+        pssm["A", 1] = 1.0
+        pssm["C", 2] = 2.0
+        pssm["A", 2] = 0.5
+        pssm["C", 1] = -1.0
+
+        seq = Residue['A', 'C']
+        pssm_score = score_sequence(pssm, seq)
+        @test pssm_score isa ProfileScore
+        @test pssm_score.score == 3.0
+        @test pssm_score.used_positions == 2
+        @test pssm_score.kind == :log_odds
+
+        @test_throws ArgumentError score_sequence(pssm, Residue['A'])
+
+        seqs_row = reshape(seq, 1, :)
+        seqs_col = reshape(seq, :, 1)
+        pssm_score_row = score_sequence(pssm, seqs_row)
+        @test pssm_score_row isa ProfileScore
+        @test pssm_score_row.score == 3.0
+        @test pssm_score_row.used_positions == 2
+        @test pssm_score_row.kind == :log_odds
+        pssm_score_col = score_sequence(pssm, seqs_col)
+        @test pssm_score_col isa ProfileScore
+        @test pssm_score_col.score == 3.0
+        @test pssm_score_col.used_positions == 2
+        @test pssm_score_col.kind == :log_odds
+
+        seqs_bad = fill(Residue('A'), 2, 3)
+        @test_throws ArgumentError score_sequence(pssm, seqs_bad)
+
+        seq_unknown = Residue['A', Residue('X')]
+        score_unknown = @test_logs (:warn, r"Residue .* not in alphabet") score_sequence(
+            pssm,
+            seq_unknown,
+        )
+        @test score_unknown isa ProfileScore
+        @test score_unknown.score == 1.0
+        @test score_unknown.used_positions == 1
+        @test score_unknown.kind == :log_odds
+
+        seq_gap = Residue['A', GAP]
+        score_gap = score_sequence(pssm, seq_gap)
+        @test score_gap isa ProfileScore
+        @test score_gap.score == 1.0
+        @test score_gap.used_positions == 1
+        @test score_gap.kind == :log_odds
+
+        ppm = PositionSpecificProbabilityMatrix(alphabet, 2)
+        ppm["A", 1] = 0.1
+        ppm["C", 2] = 0.2
+        ppm_score = score_sequence(ppm, seq)
+        @test ppm_score isa ProfileScore
+        @test isapprox(ppm_score.score, log(0.1) + log(0.2))
+        @test ppm_score.base == ℯ
+        @test isapprox(ppm_score.base^ppm_score.score, 0.02)
+        @test ppm_score.used_positions == 2
+        @test ppm_score.kind == :log_likelihood
+
+        ppm_score_row = score_sequence(ppm, seqs_row)
+        @test ppm_score_row isa ProfileScore
+        @test isapprox(ppm_score_row.score, ppm_score.score)
+        @test ppm_score_row.base == ppm_score.base
+        @test ppm_score_row.used_positions == ppm_score.used_positions
+        @test ppm_score_row.kind == :log_likelihood
+
+        ppm_score_bits = score_sequence(ppm, seq; base = 2)
+        @test ppm_score_bits isa ProfileScore
+        @test isapprox(ppm_score_bits.score, ppm_score.score / log(2))
+        @test ppm_score_bits.base == 2
+        @test isapprox(ppm_score_bits.base^ppm_score_bits.score, 0.02)
+        @test ppm_score_bits.kind == :log_likelihood
+
+        seq_unknown_ppm = Residue['A', Residue('X')]
+        ppm_unknown = @test_logs (:warn, r"Residue .* not in alphabet") score_sequence(
+            ppm,
+            seq_unknown_ppm,
+        )
+        @test ppm_unknown isa ProfileScore
+        @test isapprox(ppm_unknown.score, log(0.1))
+        @test ppm_unknown.base == ℯ
+        @test isapprox(ppm_unknown.base^ppm_unknown.score, 0.1)
+        @test ppm_unknown.used_positions == 1
+        @test ppm_unknown.kind == :log_likelihood
+
+        seq_gap_ppm = Residue['A', GAP]
+        ppm_gap = score_sequence(ppm, seq_gap_ppm)
+        @test ppm_gap isa ProfileScore
+        @test isapprox(ppm_gap.score, log(0.1))
+        @test ppm_gap.base == ℯ
+        @test isapprox(ppm_gap.base^ppm_gap.score, 0.1)
+        @test ppm_gap.used_positions == 1
+        @test ppm_gap.kind == :log_likelihood
+
+        ppm_zero = PositionSpecificProbabilityMatrix(alphabet, 2)
+        ppm_zero["A", 1] = 0.1
+        ppm_zero["C", 2] = 0.0
+        zero_score = score_sequence(ppm_zero, seq)
+        @test zero_score isa ProfileScore
+        @test zero_score.score == -Inf
+        @test zero_score.base == ℯ
+        @test zero_score.used_positions == 2
+        @test zero_score.kind == :log_likelihood
+
+        @testset "MSA and sequence types" begin
+            seq_vec = Residue['A', 'C', 'D']
+            msa_matrix = permutedims(seq_vec)
+
+            msa = MultipleSequenceAlignment(msa_matrix)
+            annot_msa = AnnotatedMultipleSequenceAlignment(msa_matrix)
+
+            pssm_types = PositionSpecificScoringMatrix(alphabet, 3)
+            pssm_types["A", 1] = 0.5
+            pssm_types["C", 2] = 1.0
+            pssm_types["D", 3] = -0.25
+
+            expected = score_sequence(pssm_types, seq_vec)
+            @test expected.used_positions == 3
+            @test expected.kind == :log_odds
+
+            aligned_seq = getsequence(msa, 1)
+            annot_aligned_seq = getsequence(annot_msa, 1)
+            unaligned_seq = AnnotatedSequence(annot_aligned_seq)
+
+            @test score_sequence(pssm_types, msa) == expected
+            @test score_sequence(pssm_types, annot_msa) == expected
+            @test score_sequence(pssm_types, aligned_seq) == expected
+            @test score_sequence(pssm_types, annot_aligned_seq) == expected
+            @test score_sequence(pssm_types, unaligned_seq) == expected
+        end
+    end
+
     @testset "Shape, ordering and values" begin
         msa = Residue[
             'A' 'E'

--- a/test/Information/PSSM.jl
+++ b/test/Information/PSSM.jl
@@ -104,4 +104,30 @@
         msa = reshape(res"AC", 1, :)
         @test_throws ArgumentError pssm(msa; dims = 1)
     end
+
+    @testset "Background validation" begin
+        msa = permutedims(hcat(res"AC", res"AD")) # 2 sequences, 2 columns
+
+        @testset "Length mismatch" begin
+            background = fill(1 / 19, 19)
+            @test_throws ArgumentError pssm(msa; alphabet = alphabet, background = background)
+        end
+
+        @testset "Zero sum" begin
+            background = zeros(20)
+            @test_throws DomainError pssm(msa; alphabet = alphabet, background = background)
+        end
+
+        @testset "Non-finite" begin
+            background = fill(1 / 20, 20)
+            background[1] = NaN
+            @test_throws DomainError pssm(msa; alphabet = alphabet, background = background)
+        end
+
+        @testset "Negative" begin
+            background = fill(1 / 20, 20)
+            background[1] = -0.1
+            @test_throws DomainError pssm(msa; alphabet = alphabet, background = background)
+        end
+    end
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -73,6 +73,7 @@ end
     include("Information/CorrectedMutualInformation.jl")
     include("Information/Gaps.jl")
     include("Information/Externals.jl")
+    include("Information/PSSM.jl")
 end
 
 # PDB


### PR DESCRIPTION
## Summary
- add a PSSMResult container and pssm API to compute log-odds PSSMs from MSAs
- validate background distributions, gap handling, and zero-handling policies while using MIToS probability estimators
- cover the new functionality with targeted tests for shapes, correctness, zero policies, and all-gap columns

## Testing
- julia --project -e 'using Test; using MIToS; using MIToS.MSA; using MIToS.Information; include("test/Information/PSSM.jl")'


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6943bb5a89e8832daf1f4279bb0d87f2)