### PR TITLE
Add exact opt-in threading to mapcolpairfreq!

### DIFF
--- a/src/Information/Iterations.jl
+++ b/src/Information/Iterations.jl
@@ -35,6 +35,11 @@ _mappairfreq_kargs_doc = """
 - `diagonalvalue` (default: `zero`): Value to fill diagonal elements if `usediagonal` is `false`.
 """
 
+_mapcolpairfreq_kargs_doc = """
+- `threads` (default: `false`): If `true`, column pairs are processed in parallel using
+  thread-local scratch tables.
+"""
+
 # Residues: The output is a Named Vector
 # --------------------------------------
 
@@ -164,6 +169,70 @@ function _mappairfreq!(
     plm
 end
 
+function _mappairfreq_threaded!(
+    f::Function,
+    res_list::Vector{V},
+    plm::PairwiseListMatrix{T,true,TV},
+    table::Union{Probabilities{T,2,A},Frequencies{T,2,A}};
+    weights::WeightTypes = NoClustering(),
+    pseudocounts::Pseudocount = NoPseudocount(),
+    pseudofrequencies::Pseudofrequencies = NoPseudofrequencies(),
+    kargs...,
+) where {T,TV,A,V<:AbstractArray{Residue}}
+    nres = length(res_list)
+    tables = [deepcopy(table) for _ = 1:Threads.nthreads()]
+    list = getlist(plm)
+    Threads.@threads for i = 1:nres
+        local_table = tables[Threads.threadid()]
+        @inbounds for j = i:nres
+            k = ij2k(i, j, nres, Val{true})
+            list[k] = _mapfreq_kernel!(
+                f,
+                local_table,
+                weights,
+                pseudocounts,
+                pseudofrequencies,
+                res_list[i],
+                res_list[j];
+                kargs...,
+            )
+        end
+    end
+    plm
+end
+
+function _mappairfreq_threaded!(
+    f::Function,
+    res_list::Vector{V},
+    plm::PairwiseListMatrix{T,false,TV},
+    table::Union{Probabilities{T,2,A},Frequencies{T,2,A}};
+    weights::WeightTypes = NoClustering(),
+    pseudocounts::Pseudocount = NoPseudocount(),
+    pseudofrequencies::Pseudofrequencies = NoPseudofrequencies(),
+    kargs...,
+) where {T,TV,A,V<:AbstractArray{Residue}}
+    nres = length(res_list)
+    tables = [deepcopy(table) for _ = 1:Threads.nthreads()]
+    list = getlist(plm)
+    Threads.@threads for i = 1:(nres-1)
+        local_table = tables[Threads.threadid()]
+        @inbounds for j = (i+1):nres
+            k = ij2k(i, j, nres, Val{false})
+            list[k] = _mapfreq_kernel!(
+                f,
+                local_table,
+                weights,
+                pseudocounts,
+                pseudofrequencies,
+                res_list[i],
+                res_list[j];
+                kargs...,
+            )
+        end
+    end
+    plm
+end
+
 # Map to column pairs
 
 """
@@ -173,12 +242,14 @@ probabilities of each pair of columns from the `msa` (second argument).
 
 $_mapfreq_kargs_doc
 $_mappairfreq_kargs_doc
+$_mapcolpairfreq_kargs_doc
 """
 function mapcolpairfreq!(
     f::Function,
     msa::AbstractMatrix{Residue},
     table::Union{Probabilities{T,2,A},Frequencies{T,2,A}};
     usediagonal::Bool = true,
+    threads::Bool = false,
     diagonalvalue::T = zero(T),
     weights::WeightTypes = NoClustering(),
     pseudocounts::Pseudocount = NoPseudocount(),
@@ -190,17 +261,30 @@ function mapcolpairfreq!(
     columns = map(i -> view(residues, :, i), 1:ncol) # 2x faster than calling view inside the loop
     scores = columnpairsmatrix(msa, T, Val{usediagonal}, diagonalvalue) # Named PairwiseListMatrix
     plm = getarray(scores)
-    _mappairfreq!(
-        f,
-        columns,
-        plm,
-        table,
-        Val{usediagonal};
-        weights = weights,
-        pseudocounts = pseudocounts,
-        pseudofrequencies = pseudofrequencies,
-        kargs...,
-    )
+    if threads
+        _mappairfreq_threaded!(
+            f,
+            columns,
+            plm,
+            table;
+            weights = weights,
+            pseudocounts = pseudocounts,
+            pseudofrequencies = pseudofrequencies,
+            kargs...,
+        )
+    else
+        _mappairfreq!(
+            f,
+            columns,
+            plm,
+            table,
+            Val{usediagonal};
+            weights = weights,
+            pseudocounts = pseudocounts,
+            pseudofrequencies = pseudofrequencies,
+            kargs...,
+        )
+    end
     scores
 end
 

--- a/test/Information/Iterations.jl
+++ b/test/Information/Iterations.jl
@@ -1,5 +1,13 @@
 @testset "Iterations" begin
 
+    function _test_same_named_plm(a, b)
+        @test getlist(getarray(a)) == getlist(getarray(b))
+        @test getdiag(getarray(a)) == getdiag(getarray(b))
+        @test dimnames(a) == dimnames(b)
+        @test names(a, 1) == names(b, 1)
+        @test names(a, 2) == names(b, 2)
+    end
+
     @testset "NMI" begin
         # This is the example of MI(X, Y)/H(X, Y) from:
         #
@@ -33,6 +41,51 @@
             usediagonal = false,
         )
         @test nmi_mat == convert(Matrix{Float64}, getarray(nmi_t))
+    end
+
+    @testset "Threaded mapcolpairfreq!" begin
+        synthetic = Residue[
+            'A' 'A' 'R' 'N'
+            'A' 'R' 'R' 'N'
+            'R' 'A' 'A' 'D'
+            'R' 'R' 'A' 'D'
+            'A' 'A' 'A' 'N'
+        ]
+
+        synthetic_serial = mapcolpairfreq!(
+            Information._mutual_information,
+            synthetic,
+            Probabilities(ContingencyTable(Float64, Val{2}, UngappedAlphabet()));
+            usediagonal = true,
+            pseudocounts = AdditiveSmoothing(0.05),
+        )
+        synthetic_threaded = mapcolpairfreq!(
+            Information._mutual_information,
+            synthetic,
+            Probabilities(ContingencyTable(Float64, Val{2}, UngappedAlphabet()));
+            usediagonal = true,
+            pseudocounts = AdditiveSmoothing(0.05),
+            threads = true,
+        )
+
+        _test_same_named_plm(synthetic_serial, synthetic_threaded)
+
+        aln = read_file(joinpath(DATA, "Gaoetal2011.fasta"), FASTA)
+        serial = mapcolpairfreq!(
+            normalized_mutual_information,
+            aln,
+            Frequencies(ContingencyTable(Float64, Val{2}, UngappedAlphabet()));
+            usediagonal = false,
+        )
+        threaded = mapcolpairfreq!(
+            normalized_mutual_information,
+            aln,
+            Frequencies(ContingencyTable(Float64, Val{2}, UngappedAlphabet()));
+            usediagonal = false,
+            threads = true,
+        )
+
+        _test_same_named_plm(serial, threaded)
     end
 
     @testset "Gaps" begin


### PR DESCRIPTION
## Summary
- Add `threads::Bool = false` to `mapcolpairfreq!`.
- Keep the existing serial `_mappairfreq!` path as the default.
- Add a threaded column-pair path that uses thread-local scratch tables and writes only to disjoint output slots.

## Why the threaded path is exact
- Each column pair is computed independently with the same `_mapfreq_kernel!` used by the serial implementation.
- The threaded path does not change per-pair residue order or introduce cross-pair reductions, so each score matches the serial result exactly.
- New tests compare the full output structure for `threads=false` and `threads=true` on both a synthetic case and `Gaoetal2011.fasta`.

## Why it is thread-safe
- The threaded path allocates one deep-copied frequency/probability table per Julia thread.
- `Threads.threadid()` is used only to select thread-local scratch storage.
- Workers write only to unique `PairwiseListMatrix` slots derived from `ij2k(...)`, so there are no overlapping writes.

## Tests added
- Synthetic exact-equality test with `usediagonal=true` and additive smoothing.
- Real-fixture exact-equality test on `Gaoetal2011.fasta` with `normalized_mutual_information`.
- Existing `CorrectedMutualInformation` and gap-related tests were rerun.

## Commands run
- `using Pkg; Pkg.instantiate()`
- `MIToSTests.retest("Information")`
- `MIToSTests.retest("Iterations")` twice
- `MIToSTests.retest("CorrectedMutualInformation")` twice
- `MIToSTests.retest("Gaps")` twice
- Local timing check for `mapcolpairfreq!(normalized_mutual_information, ...)` on `Gaoetal2011.fasta`

## Timing note
- On the small `Gaoetal2011.fasta` fixture, the threaded path was slower locally due to thread overhead. This PR prioritizes exactness and thread safety over small-input speedups.